### PR TITLE
feat/2: implement UpgradeRegressionManager

### DIFF
--- a/src/contracts/TimelockMultiAdminShim.sol
+++ b/src/contracts/TimelockMultiAdminShim.sol
@@ -207,7 +207,16 @@ contract TimelockMultiAdminShim is ITimelockMultiAdminShim {
     }
   }
 
+  /// @notice Reverts if the executor is invalid.
+  /// @param _executor The address of the executor.
+  function _revertIfInvalidExecutor(address _executor) internal pure {
+    if (_executor == address(0)) {
+      revert TimelockMultiAdminShim__InvalidExecutor();
+    }
+  }
+
   /// @notice Utility function to set the admin.
+  /// @param _newAdmin The new admin.
   function _setAdmin(address _newAdmin) internal {
     if (_newAdmin == address(0)) {
       revert TimelockMultiAdminShim__InvalidAdmin();
@@ -215,12 +224,5 @@ contract TimelockMultiAdminShim is ITimelockMultiAdminShim {
 
     emit AdminSet(admin, _newAdmin);
     admin = _newAdmin;
-  }
-
-  /// @notice Reverts if the executor is invalid.
-  function _revertIfInvalidExecutor(address _executor) internal pure {
-    if (_executor == address(0)) {
-      revert TimelockMultiAdminShim__InvalidExecutor();
-    }
   }
 }

--- a/src/contracts/UpgradeRegressionManager.sol
+++ b/src/contracts/UpgradeRegressionManager.sol
@@ -1,0 +1,419 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+// Internal Libraries
+import {ITimelockTarget} from "interfaces/ITimelockTarget.sol";
+import {IUpgradeRegressionManager} from "interfaces/IUpgradeRegressionManager.sol";
+
+/// @title Upgrade Regression Manager
+/// @author [ScopeLift](https://scopelift.co)
+/// @notice Manages the lifecycle of rollback proposals, allowing the admin to propose, and the guardian to queue,
+/// cancel, or execute rollback transactions.
+/// @dev This contract coordinates a multi-phase rollback process:
+///      - Admin proposes rollback transactions.
+///      - Guardian queues them for execution within a specified window
+///      - Guardian later executes or cancels the queued rollback.
+///      - On queuing / cancelling / executing, the transactions are sent to TimelockTarget.
+contract UpgradeRegressionManager is IUpgradeRegressionManager {
+  /*///////////////////////////////////////////////////////////////
+                          Errors
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Thrown when an unauthorized caller attempts perform an action.
+  error UpgradeRegressionManager__Unauthorized();
+
+  /// @notice Thrown when an invalid address is provided.
+  error UpgradeRegressionManager__InvalidAddress();
+
+  /// @notice Thrown when an invalid rollback queue window is provided.
+  error UpgradeRegressionManager__InvalidRollbackQueueWindow();
+
+  /// @notice Thrown when the lengths of the parameters do not match.
+  error UpgradeRegressionManager__MismatchedParameters();
+
+  /// @notice Thrown when a rollback is not proposed or already queued.
+  error UpgradeRegressionManager__NotQueueable(uint256 rollbackId);
+
+  /// @notice Thrown when a rollback is not queued for execution.
+  error UpgradeRegressionManager__NotQueued(uint256 rollbackId);
+
+  /// @notice Thrown when a rollback queue has expired.
+  error UpgradeRegressionManager__Expired(uint256 rollbackId);
+
+  /// @notice Thrown when a rollback's execution time has not yet arrived.
+  error UpgradeRegressionManager__ExecutionTooEarly(uint256 rollbackId);
+
+  /// @notice Thrown when a rollback already exists.
+  error UpgradeRegressionManager__AlreadyExists(uint256 rollbackId);
+
+  /*///////////////////////////////////////////////////////////////
+                          Events
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Emitted when a rollback is proposed.
+  /// @param rollbackId The ID of the rollback.
+  /// @param expiresAt Timestamp before which the rollback must be queued for execution.
+  /// @param targets The targets of the transactions.
+  /// @param values The values of the transactions.
+  /// @param calldatas The calldatas of the transactions.
+  /// @param description The description of the rollback.
+  event RollbackProposed(
+    uint256 indexed rollbackId,
+    uint256 expiresAt,
+    address[] targets,
+    uint256[] values,
+    bytes[] calldatas,
+    string description
+  );
+
+  /// @notice Emitted when a rollback is queued.
+  /// @param rollbackId The ID of the rollback.
+  /// @param eta Timestamp after which the rollback can be executed.
+  event RollbackQueued(uint256 indexed rollbackId, uint256 eta);
+
+  /// @notice Emitted when a rollback is canceled.
+  /// @param rollbackId The ID of the rollback.
+  event RollbackCanceled(uint256 indexed rollbackId);
+
+  /// @notice Emitted when a rollback is executed.
+  /// @param rollbackId The ID of the rollback.
+  event RollbackExecuted(uint256 indexed rollbackId);
+
+  /// @notice Emitted when a new guardian is set.
+  /// @param oldGuardian The old guardian.
+  /// @param newGuardian The new guardian.
+  event GuardianSet(address indexed oldGuardian, address indexed newGuardian);
+
+  /// @notice Emitted when the rollback queue window is set.
+  /// @param oldRollbackQueueWindow The old rollback queue window.
+  /// @param newRollbackQueueWindow The new rollback queue window.
+  event RollbackQueueWindowSet(uint256 oldRollbackQueueWindow, uint256 newRollbackQueueWindow);
+
+  /// @notice Emitted when the admin is set.
+  /// @param oldAdmin The old admin.
+  /// @param newAdmin The new admin.
+  event AdminSet(address indexed oldAdmin, address indexed newAdmin);
+
+  /*///////////////////////////////////////////////////////////////
+                          State Variables
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Target for timelocked execution of rollback transactions.
+  ITimelockTarget public immutable TARGET;
+
+  /// @notice Address that manages this contract.
+  address public admin;
+
+  /// @notice Address that can execute rollback transactions.
+  address public guardian;
+
+  /// @notice Time window after a rollback is proposed during which it can be queued for execution.
+  uint256 public rollbackQueueWindow;
+
+  /// @notice Timestamp after which rollback queueing is no longer allowed.
+  mapping(uint256 rollbackId => uint256 deadline) public rollbackQueueExpiresAt;
+
+  /// @notice Time after which the rollback can be executed.
+  mapping(uint256 rollbackId => uint256 eta) public rollbackExecutableAt;
+
+  /*///////////////////////////////////////////////////////////////
+                          Constructor
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Initializes the UpgradeRegressionManager.
+  /// @param _target The target for timelocked execution of rollback transactions.
+  /// @param _admin The address that manages this contract.
+  /// @param _guardian The address that can execute rollback transactions.
+  /// @param _rollbackQueueWindow The time window after a rollback is proposed during which it can be queued for
+  /// execution.
+  constructor(ITimelockTarget _target, address _admin, address _guardian, uint256 _rollbackQueueWindow) {
+    if (address(_target) == address(0)) {
+      revert UpgradeRegressionManager__InvalidAddress();
+    }
+
+    TARGET = _target;
+
+    _setAdmin(_admin);
+    _setRollbackQueueWindow(_rollbackQueueWindow);
+    _setGuardian(_guardian);
+  }
+
+  /*///////////////////////////////////////////////////////////////
+                          External Functions
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Checks if a rollback is eligible to be queued.
+  /// @param _rollbackId The ID of the rollback.
+  /// @return True if the rollback is ready to be queued, false otherwise.
+  function isRollbackEligibleToQueue(uint256 _rollbackId) external view returns (bool) {
+    return rollbackQueueExpiresAt[_rollbackId] != 0 && block.timestamp < rollbackQueueExpiresAt[_rollbackId];
+  }
+
+  /// @notice Checks if a rollback is ready to be executed.
+  /// @param _rollbackId The ID of the rollback.
+  /// @return True if the rollback is ready to be executed, false otherwise.
+  function isRollbackReadyToExecute(uint256 _rollbackId) external view returns (bool) {
+    return rollbackExecutableAt[_rollbackId] != 0 && block.timestamp >= rollbackExecutableAt[_rollbackId];
+  }
+
+  /// @notice Proposes a rollback which can be queued for execution.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  /// @param _description The description of the rollback.
+  /// @return _rollbackId The rollback ID.
+  /// @dev Can only be called by the admin.
+  ///      Proposes a rollback by submitting the target transactions and their metadata.
+  ///      Does not queue or execute the rollback — it simply stages it for guardian review.
+  function propose(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) external returns (uint256 _rollbackId) {
+    _revertIfNotAdmin();
+    _revertIfMismatchedParameters(_targets, _values, _calldatas);
+
+    _rollbackId = getRollbackId(_targets, _values, _calldatas, _description);
+
+    // Revert if the rollback already exists.
+    if (rollbackQueueExpiresAt[_rollbackId] != 0 || rollbackExecutableAt[_rollbackId] != 0) {
+      revert UpgradeRegressionManager__AlreadyExists(_rollbackId);
+    }
+
+    // Set the time before which the rollback can be queued for execution.
+    uint256 _expiresAt = block.timestamp + rollbackQueueWindow;
+    rollbackQueueExpiresAt[_rollbackId] = _expiresAt;
+
+    emit RollbackProposed(_rollbackId, _expiresAt, _targets, _values, _calldatas, _description);
+  }
+
+  /// @notice Queues a rollback for execution.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  /// @param _description The description of the rollback.
+  /// @return _rollbackId The rollback ID.
+  /// @dev Can only be called by the guardian.
+  ///      Must be called before the rollback queue window expires (`rollbackQueueExpiresAt`).
+  ///      Queues the rollback transactions to enable optional execution during the allowed window.
+  function queue(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) external returns (uint256 _rollbackId) {
+    _revertIfNotGuardian();
+    _revertIfMismatchedParameters(_targets, _values, _calldatas);
+
+    _rollbackId = getRollbackId(_targets, _values, _calldatas, _description);
+
+    // Revert if the rollback not proposed or already queued.
+    if (rollbackQueueExpiresAt[_rollbackId] == 0) {
+      revert UpgradeRegressionManager__NotQueueable(_rollbackId);
+    }
+
+    // Revert if the rollback queue has expired.
+    if (block.timestamp >= rollbackQueueExpiresAt[_rollbackId]) {
+      revert UpgradeRegressionManager__Expired(_rollbackId);
+    }
+
+    // Set the time after which the queued rollback can be executed.
+    uint256 _eta = block.timestamp + TARGET.delay();
+    rollbackExecutableAt[_rollbackId] = _eta;
+
+    // Remove the rollback from the waiting queue since it has now been queued for execution.
+    delete rollbackQueueExpiresAt[_rollbackId];
+
+    // Queue the rollback transactions.
+    for (uint256 i = 0; i < _targets.length; i++) {
+      TARGET.queueTransaction(_targets[i], _values[i], "", _calldatas[i], 0);
+    }
+
+    emit RollbackQueued(_rollbackId, _eta);
+  }
+
+  /// @notice Cancels a previously queued rollback operation.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  /// @param _description The description of the rollback.
+  /// @return _rollbackId The rollback ID.
+  /// @dev Can only be called by the guardian.
+  ///      Removes the rollback record, making it no longer executable.
+  ///      Intended for cases where a previously queued rollback is determined to be unnecessary or invalid.
+  function cancel(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) external returns (uint256 _rollbackId) {
+    _revertIfNotGuardian();
+    _revertIfMismatchedParameters(_targets, _values, _calldatas);
+
+    _rollbackId = getRollbackId(_targets, _values, _calldatas, _description);
+
+    // Revert if the rollback is not queued for execution.
+    if (rollbackExecutableAt[_rollbackId] == 0) {
+      revert UpgradeRegressionManager__NotQueued(_rollbackId);
+    }
+
+    // Remove the rollback from execution queue
+    delete rollbackExecutableAt[_rollbackId];
+
+    // Cancel the rollback transactions.
+    for (uint256 i = 0; i < _targets.length; i++) {
+      TARGET.cancelTransaction(_targets[i], _values[i], "", _calldatas[i], 0);
+    }
+
+    emit RollbackCanceled(_rollbackId);
+  }
+
+  ///  @notice Executes a previously queued rollback by the guardian, forwarding the call to each target contract.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  /// @param _description The description of the rollback.
+  /// @return _rollbackId The rollback ID.
+  /// @dev Can only be called by the guardian.
+  ///      Executes the queued rollback transactions after the execution window has begun (`rollbackExecutableAt`).
+  ///      Each transaction is forwarded to its target contract and executed sequentially.
+  function execute(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) external returns (uint256 _rollbackId) {
+    _revertIfNotGuardian();
+    _revertIfMismatchedParameters(_targets, _values, _calldatas);
+
+    _rollbackId = getRollbackId(_targets, _values, _calldatas, _description);
+
+    if (rollbackExecutableAt[_rollbackId] == 0) {
+      revert UpgradeRegressionManager__NotQueued(_rollbackId);
+    }
+
+    if (block.timestamp < rollbackExecutableAt[_rollbackId]) {
+      revert UpgradeRegressionManager__ExecutionTooEarly(_rollbackId);
+    }
+
+    // Remove the rollback from the execution queue.
+    delete rollbackExecutableAt[_rollbackId];
+
+    // Execute the rollback.
+    for (uint256 i = 0; i < _targets.length; i++) {
+      TARGET.executeTransaction(_targets[i], _values[i], "", _calldatas[i], 0);
+    }
+
+    emit RollbackExecuted(_rollbackId);
+  }
+
+  /// @notice Sets the guardian.
+  /// @param _newGuardian The new guardian.
+  /// @dev Can only be called by the admin.
+  function setGuardian(address _newGuardian) external {
+    _revertIfNotAdmin();
+    _setGuardian(_newGuardian);
+  }
+
+  /// @notice Sets the rollback queue window.
+  /// @param _newRollbackQueueWindow The new rollback queue window.
+  /// @dev Can only be called by the admin.
+  function setRollbackQueueWindow(uint256 _newRollbackQueueWindow) external {
+    _revertIfNotAdmin();
+    _setRollbackQueueWindow(_newRollbackQueueWindow);
+  }
+
+  /// @notice Sets the admin.
+  /// @param _newAdmin The new admin.
+  /// @dev Can only be called by the admin.
+  function setAdmin(address _newAdmin) external {
+    _revertIfNotAdmin();
+    _setAdmin(_newAdmin);
+  }
+
+  /*///////////////////////////////////////////////////////////////
+                          Public Functions
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Calculates the rollback ID for a given set of parameters.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  /// @param _description The description of the rollback.
+  /// @return The rollback ID.
+  /// @dev This rollback id can be produced from the rollback data which is part of the {RollbackCreated} event.
+  ///      It can even be computed in advance, before the rollback is proposed.
+  function getRollbackId(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) public pure returns (uint256) {
+    return uint256(keccak256(abi.encode(_targets, _values, _calldatas, _description)));
+  }
+
+  /*///////////////////////////////////////////////////////////////
+                        Internal Functions
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Reverts if the caller is not the admin.
+  function _revertIfNotAdmin() internal view {
+    if (msg.sender != admin) {
+      revert UpgradeRegressionManager__Unauthorized();
+    }
+  }
+
+  /// @notice Reverts if the caller is not the guardian.
+  function _revertIfNotGuardian() internal view {
+    if (msg.sender != guardian) {
+      revert UpgradeRegressionManager__Unauthorized();
+    }
+  }
+
+  /// @notice Reverts if the lengths of the parameters do not match.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  function _revertIfMismatchedParameters(address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas)
+    internal
+    pure
+  {
+    if (_targets.length != _values.length || _targets.length != _calldatas.length) {
+      revert UpgradeRegressionManager__MismatchedParameters();
+    }
+  }
+
+  /// @notice Utility function to set the guardian.
+  /// @param _newGuardian The new guardian.
+  function _setGuardian(address _newGuardian) internal {
+    if (_newGuardian == address(0)) {
+      revert UpgradeRegressionManager__InvalidAddress();
+    }
+
+    emit GuardianSet(guardian, _newGuardian);
+    guardian = _newGuardian;
+  }
+
+  /// @notice Utility function to set the rollback queue window.
+  /// @param _newRollbackQueueWindow The new rollback queue window.
+  function _setRollbackQueueWindow(uint256 _newRollbackQueueWindow) internal {
+    if (_newRollbackQueueWindow == 0) {
+      revert UpgradeRegressionManager__InvalidRollbackQueueWindow();
+    }
+
+    emit RollbackQueueWindowSet(rollbackQueueWindow, _newRollbackQueueWindow);
+    rollbackQueueWindow = _newRollbackQueueWindow;
+  }
+
+  /// @notice Utility function to set the admin.
+  /// @param _newAdmin The new admin.
+  function _setAdmin(address _newAdmin) internal {
+    if (_newAdmin == address(0)) {
+      revert UpgradeRegressionManager__InvalidAddress();
+    }
+
+    emit AdminSet(admin, _newAdmin);
+    admin = _newAdmin;
+  }
+}

--- a/src/interfaces/ITimelockTarget.sol
+++ b/src/interfaces/ITimelockTarget.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title ITimelockTarget
+/// @author [ScopeLift](https://scopelift.co)
+/// @notice Minimal interface for interacting with a timelock-compatible target used by UpgradeRegressionManager.
+/// @dev This interface represents a simplified subset of the
+///      [ICompoundTimelock](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/6079eb3f01d5a37ae23e7e72d6909852566bc2e3/contracts/vendor/compound/ICompoundTimelock.sol)
+///      contract, tailored for use by UpgradeRegressionManager.
+interface ITimelockTarget {
+  /// @notice Queues a transaction on the timelock.
+  /// @param target The address of the contract to call.
+  /// @param value The value to send with the transaction.
+  /// @param signature The function signature to call.
+  /// @param data The data to send with the transaction.
+  /// @param eta The eta of the transaction.
+  /// @return The tx hash of the queued transaction.
+  function queueTransaction(address target, uint256 value, string memory signature, bytes memory data, uint256 eta)
+    external
+    returns (bytes memory);
+
+  /// @notice Cancels a transaction on the timelock.
+  /// @param target The address of the contract to call.
+  /// @param value The value to send with the transaction.
+  /// @param signature The function signature to call.
+  /// @param data The data to send with the transaction.
+  /// @param eta The eta of the transaction.
+  function cancelTransaction(address target, uint256 value, string memory signature, bytes memory data, uint256 eta)
+    external;
+
+  /// @notice Executes a transaction on the timelock.
+  /// @param target The address of the contract to call.
+  /// @param value The value to send with the transaction.
+  /// @param signature The function signature to call.
+  /// @param data The data to send with the transaction.
+  /// @param eta The eta of the transaction.
+  /// @return The data returned by the transaction.
+  function executeTransaction(address target, uint256 value, string memory signature, bytes memory data, uint256 eta)
+    external
+    payable
+    returns (bytes memory);
+
+  /// @notice Returns the delay of the timelock.
+  /// @return The delay of the timelock.
+  function delay() external view returns (uint256);
+}

--- a/src/interfaces/IUpgradeRegressionManager.sol
+++ b/src/interfaces/IUpgradeRegressionManager.sol
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+// Internal Libraries
+import {ITimelockTarget} from "interfaces/ITimelockTarget.sol";
+
+interface IUpgradeRegressionManager {
+  /*///////////////////////////////////////////////////////////////
+                     Public Storage 
+  //////////////////////////////////////////////////////////////*/
+
+  function TARGET() external view returns (ITimelockTarget);
+
+  function admin() external view returns (address);
+
+  function guardian() external view returns (address);
+
+  function rollbackQueueWindow() external view returns (uint256);
+
+  function rollbackQueueExpiresAt(uint256 _rollbackId) external view returns (uint256);
+
+  function rollbackExecutableAt(uint256 _rollbackId) external view returns (uint256);
+
+  /*///////////////////////////////////////////////////////////////
+                     External Functions 
+  //////////////////////////////////////////////////////////////*/
+
+  function isRollbackEligibleToQueue(uint256 _rollbackId) external view returns (bool);
+
+  function isRollbackReadyToExecute(uint256 _rollbackId) external view returns (bool);
+
+  function propose(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) external returns (uint256 _rollbackId);
+
+  function queue(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) external returns (uint256 _rollbackId);
+
+  function cancel(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) external returns (uint256 _rollbackId);
+
+  function execute(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) external returns (uint256 _rollbackId);
+
+  function setGuardian(address _newGuardian) external;
+
+  function setRollbackQueueWindow(uint256 _newRollbackQueueWindow) external;
+
+  function setAdmin(address _newAdmin) external;
+
+  /*///////////////////////////////////////////////////////////////
+                     Public Functions 
+  //////////////////////////////////////////////////////////////*/
+
+  function getRollbackId(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) external view returns (uint256 _rollbackId);
+}

--- a/test/UpgradeRegressionManager.unit.t.sol
+++ b/test/UpgradeRegressionManager.unit.t.sol
@@ -1,0 +1,1107 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+// Contract Imports
+import {UpgradeRegressionManager} from "src/contracts/UpgradeRegressionManager.sol";
+import {ITimelockTarget} from "src/interfaces/ITimelockTarget.sol";
+
+// Test Imports
+import {Test} from "forge-std/Test.sol";
+import {MockTimelockTarget} from "test/mocks/MockTimelockTarget.sol";
+
+contract UpgradeRegressionManagerTest is Test {
+  UpgradeRegressionManager public upgradeRegressionManager;
+
+  MockTimelockTarget public timelockTarget;
+
+  address public guardian = makeAddr("guardian");
+  address public admin = makeAddr("admin");
+  uint256 public rollbackQueueWindow = 1 days;
+
+  function setUp() external {
+    timelockTarget = new MockTimelockTarget();
+    upgradeRegressionManager = new UpgradeRegressionManager(timelockTarget, admin, guardian, rollbackQueueWindow);
+  }
+
+  function _assumeSafeAdmin(address _admin) internal pure {
+    vm.assume(_admin != address(0));
+  }
+
+  function _assumeSafeGuardian(address _guardian) internal pure {
+    vm.assume(_guardian != address(0));
+  }
+
+  function _assumeSafeTimelockTarget(address _timelockTarget) internal pure {
+    vm.assume(_timelockTarget != address(0));
+  }
+
+  function _boundToRealisticRollbackQueueWindow(uint256 _rollbackQueueWindow) internal pure returns (uint256) {
+    return bound(_rollbackQueueWindow, 1 hours, 20 days);
+  }
+
+  function _assumeSafeInitParams(
+    address _timelockTarget,
+    address _admin,
+    address _guardian,
+    uint256 _rollbackQueueWindow
+  ) internal pure returns (uint256) {
+    _assumeSafeTimelockTarget(_timelockTarget);
+    _assumeSafeAdmin(_admin);
+    _assumeSafeGuardian(_guardian);
+    return _boundToRealisticRollbackQueueWindow(_rollbackQueueWindow);
+  }
+
+  function _proposeRollback(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) internal returns (uint256 _rollbackId) {
+    vm.prank(admin);
+    _rollbackId = upgradeRegressionManager.propose(_targets, _values, _calldatas, _description);
+  }
+
+  function _proposeAndQueueRollback(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) internal returns (uint256 _rollbackId) {
+    _proposeRollback(_targets, _values, _calldatas, _description);
+    vm.prank(guardian);
+    _rollbackId = upgradeRegressionManager.queue(_targets, _values, _calldatas, _description);
+  }
+
+  function toDynamicArrays(
+    address[2] memory _fixedTargets,
+    uint256[2] memory _fixedValues,
+    bytes[2] memory _fixedCalldatas
+  ) internal pure returns (address[] memory targets, uint256[] memory values, bytes[] memory calldatas) {
+    targets = new address[](2);
+    values = new uint256[](2);
+    calldatas = new bytes[](2);
+
+    for (uint256 i = 0; i < 2; i++) {
+      targets[i] = _fixedTargets[i];
+      values[i] = _fixedValues[i];
+      calldatas[i] = _fixedCalldatas[i];
+    }
+  }
+}
+
+contract Constructor is UpgradeRegressionManagerTest {
+  function testFuzz_SetsIntializeParameters(
+    address _timelockTarget,
+    address _admin,
+    address _guardian,
+    uint256 _rollbackQueueWindow
+  ) external {
+    _rollbackQueueWindow = _assumeSafeInitParams(_timelockTarget, _admin, _guardian, _rollbackQueueWindow);
+
+    UpgradeRegressionManager _upgradeRegressionManager =
+      new UpgradeRegressionManager(ITimelockTarget(_timelockTarget), _admin, _guardian, _rollbackQueueWindow);
+
+    assertEq(address(_upgradeRegressionManager.TARGET()), _timelockTarget);
+    assertEq(_upgradeRegressionManager.admin(), _admin);
+    assertEq(_upgradeRegressionManager.guardian(), _guardian);
+    assertEq(_upgradeRegressionManager.rollbackQueueWindow(), _rollbackQueueWindow);
+  }
+
+  function testFuzz_EmitsRollbackQueueWindowSet(
+    address _timelockTarget,
+    address _admin,
+    address _guardian,
+    uint256 _rollbackQueueWindow
+  ) external {
+    _rollbackQueueWindow = _assumeSafeInitParams(_timelockTarget, _admin, _guardian, _rollbackQueueWindow);
+
+    vm.expectEmit(true, true, true, true);
+    emit UpgradeRegressionManager.RollbackQueueWindowSet(0, _rollbackQueueWindow);
+    new UpgradeRegressionManager(ITimelockTarget(_timelockTarget), _admin, _guardian, _rollbackQueueWindow);
+  }
+
+  function testFuzz_EmitsGuardianSet(
+    address _timelockTarget,
+    address _admin,
+    address _guardian,
+    uint256 _rollbackQueueWindow
+  ) external {
+    _rollbackQueueWindow = _assumeSafeInitParams(_timelockTarget, _admin, _guardian, _rollbackQueueWindow);
+
+    vm.expectEmit(true, true, true, true);
+    emit UpgradeRegressionManager.GuardianSet(address(0), _guardian);
+    new UpgradeRegressionManager(ITimelockTarget(_timelockTarget), _admin, _guardian, _rollbackQueueWindow);
+  }
+
+  function testFuzz_RevertIf_TimelockTargetIsZeroAddress(
+    address _admin,
+    address _guardian,
+    uint256 _rollbackQueueWindow
+  ) external {
+    _assumeSafeAdmin(_admin);
+    _assumeSafeGuardian(_guardian);
+    _rollbackQueueWindow = _boundToRealisticRollbackQueueWindow(_rollbackQueueWindow);
+
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__InvalidAddress.selector);
+    new UpgradeRegressionManager(ITimelockTarget(address(0)), _admin, _guardian, _rollbackQueueWindow);
+  }
+
+  function testFuzz_RevertIf_AdminIsZeroAddress(
+    address _timelockTarget,
+    address _guardian,
+    uint256 _rollbackQueueWindow
+  ) external {
+    _assumeSafeTimelockTarget(_timelockTarget);
+    _assumeSafeGuardian(_guardian);
+    _rollbackQueueWindow = _boundToRealisticRollbackQueueWindow(_rollbackQueueWindow);
+
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__InvalidAddress.selector);
+    new UpgradeRegressionManager(ITimelockTarget(_timelockTarget), address(0), _guardian, _rollbackQueueWindow);
+  }
+
+  function testFuzz_RevertIf_GuardianIsZeroAddress(
+    address _timelockTarget,
+    address _admin,
+    uint256 _rollbackQueueWindow
+  ) external {
+    _assumeSafeTimelockTarget(_timelockTarget);
+    _assumeSafeAdmin(_admin);
+    _rollbackQueueWindow = _boundToRealisticRollbackQueueWindow(_rollbackQueueWindow);
+
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__InvalidAddress.selector);
+    new UpgradeRegressionManager(ITimelockTarget(_timelockTarget), _admin, address(0), _rollbackQueueWindow);
+  }
+
+  function testFuzz_RevertIf_RollbackQueueWindowIsZero(address _timelockTarget, address _admin, address _guardian)
+    external
+  {
+    _assumeSafeTimelockTarget(_timelockTarget);
+    _assumeSafeAdmin(_admin);
+    _assumeSafeGuardian(_guardian);
+
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__InvalidRollbackQueueWindow.selector);
+    new UpgradeRegressionManager(ITimelockTarget(_timelockTarget), _admin, _guardian, 0);
+  }
+}
+
+contract Propose is UpgradeRegressionManagerTest {
+  function testFuzz_AllowTheAdminToProposeARollbackAndReturnsTheRollbackId(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    uint256 _computedRollbackId = upgradeRegressionManager.getRollbackId(_targets, _values, _calldatas, _description);
+
+    vm.prank(admin);
+    uint256 _rollbackId = upgradeRegressionManager.propose(_targets, _values, _calldatas, _description);
+
+    assertEq(_rollbackId, _computedRollbackId);
+  }
+
+  function testFuzz_EmitsRollbackProposed(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    uint256 _computedRollbackId = upgradeRegressionManager.getRollbackId(_targets, _values, _calldatas, _description);
+
+    vm.expectEmit(true, true, true, true);
+    emit UpgradeRegressionManager.RollbackProposed(
+      _computedRollbackId, block.timestamp + rollbackQueueWindow, _targets, _values, _calldatas, _description
+    );
+
+    vm.prank(admin);
+    upgradeRegressionManager.propose(_targets, _values, _calldatas, _description);
+  }
+
+  function testFuzz_AddsOnlyToRollbackQueue(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    uint256 _computedRollbackId = upgradeRegressionManager.getRollbackId(_targets, _values, _calldatas, _description);
+
+    assertEq(upgradeRegressionManager.rollbackQueueExpiresAt(_computedRollbackId), 0);
+
+    vm.prank(admin);
+    upgradeRegressionManager.propose(_targets, _values, _calldatas, _description);
+
+    assertEq(
+      upgradeRegressionManager.rollbackQueueExpiresAt(_computedRollbackId), block.timestamp + rollbackQueueWindow
+    );
+    assertEq(upgradeRegressionManager.rollbackExecutableAt(_computedRollbackId), 0);
+  }
+
+  function testFuzz_SetsTheExpirationTimeBasedOnRollbackQueueWindow(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description,
+    uint256 _rollbackQueueWindow
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    _rollbackQueueWindow = _boundToRealisticRollbackQueueWindow(_rollbackQueueWindow);
+
+    vm.startPrank(admin);
+    // Set the rollback queue window to the new value.
+    upgradeRegressionManager.setRollbackQueueWindow(_rollbackQueueWindow);
+    uint256 _rollbackId = upgradeRegressionManager.propose(_targets, _values, _calldatas, _description);
+    vm.stopPrank();
+
+    assertEq(upgradeRegressionManager.rollbackQueueExpiresAt(_rollbackId), block.timestamp + _rollbackQueueWindow);
+  }
+
+  function testFuzz_RevertIf_RollbackAlreadyExists(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    vm.startPrank(admin);
+    uint256 _rollbackId = upgradeRegressionManager.propose(_targets, _values, _calldatas, _description);
+    vm.expectRevert(
+      abi.encodeWithSelector(UpgradeRegressionManager.UpgradeRegressionManager__AlreadyExists.selector, _rollbackId)
+    );
+    upgradeRegressionManager.propose(_targets, _values, _calldatas, _description);
+    vm.stopPrank();
+  }
+
+  function testFuzz_RevertIf_MismatchedParameters(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    uint256[] memory _valuesMismatch = new uint256[](1);
+    bytes[] memory _calldatasMismatch = new bytes[](1);
+
+    vm.startPrank(admin);
+
+    // target and values length mismatch
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__MismatchedParameters.selector);
+    upgradeRegressionManager.propose(_targets, _valuesMismatch, _calldatas, _description);
+
+    // target and calldatas length mismatch
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__MismatchedParameters.selector);
+    upgradeRegressionManager.propose(_targets, _values, _calldatasMismatch, _description);
+
+    vm.stopPrank();
+  }
+
+  function testFuzz_RevertIf_CallerIsNotAdmin(
+    address _caller,
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    vm.assume(_caller != admin);
+
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__Unauthorized.selector);
+    vm.prank(_caller);
+    upgradeRegressionManager.propose(_targets, _values, _calldatas, _description);
+  }
+}
+
+contract Queue is UpgradeRegressionManagerTest {
+  function testFuzz_ForwardsParametersToTimelockTargetWhenCallerIsGuardian(
+    uint256 _delay,
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    _proposeRollback(_targets, _values, _calldatas, _description);
+
+    _delay = bound(_delay, 0, rollbackQueueWindow - 1);
+    vm.warp(block.timestamp + _delay);
+
+    vm.prank(guardian);
+    upgradeRegressionManager.queue(_targets, _values, _calldatas, _description);
+
+    MockTimelockTarget.TimelockTransactionCall[] memory _lastQueueTransactionCalls =
+      timelockTarget.lastParam__queueTransactions__();
+
+    assertEq(_lastQueueTransactionCalls.length, 2);
+
+    assertEq(_lastQueueTransactionCalls[0].target, _targets[0]);
+    assertEq(_lastQueueTransactionCalls[0].value, _values[0]);
+    assertEq(_lastQueueTransactionCalls[0].signature, "");
+    assertEq(_lastQueueTransactionCalls[0].data, _calldatas[0]);
+    assertEq(_lastQueueTransactionCalls[0].eta, 0);
+
+    assertEq(_lastQueueTransactionCalls[1].target, _targets[1]);
+    assertEq(_lastQueueTransactionCalls[1].value, _values[1]);
+    assertEq(_lastQueueTransactionCalls[1].signature, "");
+    assertEq(_lastQueueTransactionCalls[1].data, _calldatas[1]);
+    assertEq(_lastQueueTransactionCalls[1].eta, 0);
+  }
+
+  function testFuzz_SetsTheExecutableTimeToAfterTimelockTargetDelay(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    uint256 _rollbackId = _proposeRollback(_targets, _values, _calldatas, _description);
+
+    vm.prank(guardian);
+    upgradeRegressionManager.queue(_targets, _values, _calldatas, _description);
+    assertEq(upgradeRegressionManager.rollbackExecutableAt(_rollbackId), block.timestamp + timelockTarget.delay());
+  }
+
+  function testFuzz_EmitsRollbackQueued(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    uint256 _rollbackId = _proposeRollback(_targets, _values, _calldatas, _description);
+
+    vm.expectEmit(true, true, true, true);
+    emit UpgradeRegressionManager.RollbackQueued(_rollbackId, block.timestamp + timelockTarget.delay());
+
+    vm.prank(guardian);
+    upgradeRegressionManager.queue(_targets, _values, _calldatas, _description);
+  }
+
+  function testFuzz_RemovesFromRollbackQueue(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    uint256 _rollbackId = _proposeRollback(_targets, _values, _calldatas, _description);
+
+    vm.prank(guardian);
+    upgradeRegressionManager.queue(_targets, _values, _calldatas, _description);
+
+    assertEq(upgradeRegressionManager.rollbackQueueExpiresAt(_rollbackId), 0);
+  }
+
+  function testFuzz_AddsToRollbackExecutableAtQueue(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    uint256 _rollbackId = _proposeRollback(_targets, _values, _calldatas, _description);
+
+    // Ensure that the rollback is not already queued.
+    assertEq(upgradeRegressionManager.rollbackExecutableAt(_rollbackId), 0);
+
+    vm.prank(guardian);
+    upgradeRegressionManager.queue(_targets, _values, _calldatas, _description);
+
+    assertEq(upgradeRegressionManager.rollbackExecutableAt(_rollbackId), block.timestamp + timelockTarget.delay());
+  }
+
+  function testFuzz_RevertIf_CallerIsNotGuardian(
+    address _caller,
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    vm.assume(_caller != guardian);
+
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__Unauthorized.selector);
+    vm.prank(_caller);
+    upgradeRegressionManager.queue(_targets, _values, _calldatas, _description);
+  }
+
+  function testFuzz_RevertIf_RollbackDoesNotExist(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    uint256 _rollbackId = upgradeRegressionManager.getRollbackId(_targets, _values, _calldatas, _description);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(UpgradeRegressionManager.UpgradeRegressionManager__NotQueueable.selector, _rollbackId)
+    );
+    vm.prank(guardian);
+    upgradeRegressionManager.queue(_targets, _values, _calldatas, _description);
+  }
+
+  function testFuzz_RevertIf_RollbackIsAlreadyQueued(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    uint256 _rollbackId = _proposeRollback(_targets, _values, _calldatas, _description);
+
+    vm.prank(guardian);
+    upgradeRegressionManager.queue(_targets, _values, _calldatas, _description);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(UpgradeRegressionManager.UpgradeRegressionManager__NotQueueable.selector, _rollbackId)
+    );
+    vm.prank(guardian);
+    upgradeRegressionManager.queue(_targets, _values, _calldatas, _description);
+  }
+
+  function testFuzz_RevertIf_RollbackQueueHasExpired(
+    uint256 _delay,
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    uint256 _rollbackId = _proposeRollback(_targets, _values, _calldatas, _description);
+
+    _delay = bound(_delay, rollbackQueueWindow, type(uint256).max - block.timestamp);
+
+    vm.warp(block.timestamp + _delay);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(UpgradeRegressionManager.UpgradeRegressionManager__Expired.selector, _rollbackId)
+    );
+    vm.prank(guardian);
+    upgradeRegressionManager.queue(_targets, _values, _calldatas, _description);
+  }
+
+  function testFuzz_RevertIf_MismatchedParameters(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    uint256[] memory _valuesMismatch = new uint256[](1);
+    bytes[] memory _calldatasMismatch = new bytes[](1);
+
+    vm.startPrank(guardian);
+    // target and values length mismatch
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__MismatchedParameters.selector);
+    upgradeRegressionManager.queue(_targets, _valuesMismatch, _calldatas, _description);
+
+    // target and calldatas length mismatch
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__MismatchedParameters.selector);
+    upgradeRegressionManager.queue(_targets, _values, _calldatasMismatch, _description);
+
+    vm.stopPrank();
+  }
+}
+
+contract Cancel is UpgradeRegressionManagerTest {
+  function testFuzz_ForwardsParametersToTargetTimelockWhenCallerIsGuardian(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+    _proposeAndQueueRollback(_targets, _values, _calldatas, _description);
+    vm.prank(guardian);
+    upgradeRegressionManager.cancel(_targets, _values, _calldatas, _description);
+
+    MockTimelockTarget.TimelockTransactionCall[] memory _lastCancelTransactionCalls =
+      timelockTarget.lastParam__cancelTransactions__();
+
+    assertEq(_lastCancelTransactionCalls.length, 2);
+
+    assertEq(_lastCancelTransactionCalls[0].target, _targets[0]);
+    assertEq(_lastCancelTransactionCalls[0].value, _values[0]);
+    assertEq(_lastCancelTransactionCalls[0].signature, "");
+    assertEq(_lastCancelTransactionCalls[0].data, _calldatas[0]);
+    assertEq(_lastCancelTransactionCalls[0].eta, 0);
+
+    assertEq(_lastCancelTransactionCalls[1].target, _targets[1]);
+    assertEq(_lastCancelTransactionCalls[1].value, _values[1]);
+    assertEq(_lastCancelTransactionCalls[1].signature, "");
+    assertEq(_lastCancelTransactionCalls[1].data, _calldatas[1]);
+    assertEq(_lastCancelTransactionCalls[1].eta, 0);
+  }
+
+  function testFuzz_EmitsRollbackCanceled(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+    uint256 _rollbackId = _proposeAndQueueRollback(_targets, _values, _calldatas, _description);
+
+    vm.expectEmit(true, true, true, true);
+    emit UpgradeRegressionManager.RollbackCanceled(_rollbackId);
+
+    vm.prank(guardian);
+    upgradeRegressionManager.cancel(_targets, _values, _calldatas, _description);
+  }
+
+  function testFuzz_RemovesFromRollbackExecutableAtQueue(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+    uint256 _rollbackId = _proposeAndQueueRollback(_targets, _values, _calldatas, _description);
+
+    assertEq(upgradeRegressionManager.rollbackExecutableAt(_rollbackId), block.timestamp + timelockTarget.delay());
+    vm.prank(guardian);
+    upgradeRegressionManager.cancel(_targets, _values, _calldatas, _description);
+
+    assertEq(upgradeRegressionManager.rollbackExecutableAt(_rollbackId), 0);
+  }
+
+  function testFuzz_RevertIf_RollbackWasNeverProposed(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+    uint256 _computedRollbackId = upgradeRegressionManager.getRollbackId(_targets, _values, _calldatas, _description);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(UpgradeRegressionManager.UpgradeRegressionManager__NotQueued.selector, _computedRollbackId)
+    );
+    vm.prank(guardian);
+    upgradeRegressionManager.cancel(_targets, _values, _calldatas, _description);
+  }
+
+  function testFuzz_RevertIf_RollbackWasAlreadyCanceled(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+    uint256 _rollbackId = _proposeAndQueueRollback(_targets, _values, _calldatas, _description);
+
+    vm.prank(guardian);
+    upgradeRegressionManager.cancel(_targets, _values, _calldatas, _description);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(UpgradeRegressionManager.UpgradeRegressionManager__NotQueued.selector, _rollbackId)
+    );
+    vm.prank(guardian);
+    upgradeRegressionManager.cancel(_targets, _values, _calldatas, _description);
+  }
+
+  function testFuzz_RevertIf_RollbackWasAlreadyExecuted(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+    uint256 _rollbackId = _proposeAndQueueRollback(_targets, _values, _calldatas, _description);
+
+    vm.warp(block.timestamp + timelockTarget.delay());
+    vm.prank(guardian);
+    upgradeRegressionManager.execute(_targets, _values, _calldatas, _description);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(UpgradeRegressionManager.UpgradeRegressionManager__NotQueued.selector, _rollbackId)
+    );
+    vm.prank(guardian);
+    upgradeRegressionManager.cancel(_targets, _values, _calldatas, _description);
+  }
+
+  function testFuzz_RevertIf_CallerIsNotGuardian(
+    address _caller,
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+    vm.assume(_caller != guardian);
+
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__Unauthorized.selector);
+    vm.prank(_caller);
+    upgradeRegressionManager.cancel(_targets, _values, _calldatas, _description);
+  }
+
+  function testFuzz_RevertIf_MismatchedParameters(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    uint256[] memory _valuesMismatch = new uint256[](1);
+    bytes[] memory _calldatasMismatch = new bytes[](1);
+
+    vm.startPrank(guardian);
+    // target and values length mismatch
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__MismatchedParameters.selector);
+    upgradeRegressionManager.cancel(_targets, _valuesMismatch, _calldatas, _description);
+
+    // target and calldatas length mismatch
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__MismatchedParameters.selector);
+    upgradeRegressionManager.cancel(_targets, _values, _calldatasMismatch, _description);
+
+    vm.stopPrank();
+  }
+}
+
+contract Execute is UpgradeRegressionManagerTest {
+  function testFuzz_ForwardsParametersToTargetTimelockWhenCallerIsGuardian(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+    _proposeAndQueueRollback(_targets, _values, _calldatas, _description);
+
+    vm.warp(block.timestamp + timelockTarget.delay());
+    vm.prank(guardian);
+    upgradeRegressionManager.execute(_targets, _values, _calldatas, _description);
+
+    MockTimelockTarget.TimelockTransactionCall[] memory _lastExecuteTransactionCalls =
+      timelockTarget.lastParam__executeTransactions__();
+
+    assertEq(_lastExecuteTransactionCalls.length, 2);
+
+    assertEq(_lastExecuteTransactionCalls[0].target, _targets[0]);
+    assertEq(_lastExecuteTransactionCalls[0].value, _values[0]);
+    assertEq(_lastExecuteTransactionCalls[0].signature, "");
+    assertEq(_lastExecuteTransactionCalls[0].data, _calldatas[0]);
+    assertEq(_lastExecuteTransactionCalls[0].eta, 0);
+
+    assertEq(_lastExecuteTransactionCalls[1].target, _targets[1]);
+    assertEq(_lastExecuteTransactionCalls[1].value, _values[1]);
+    assertEq(_lastExecuteTransactionCalls[1].signature, "");
+    assertEq(_lastExecuteTransactionCalls[1].data, _calldatas[1]);
+    assertEq(_lastExecuteTransactionCalls[1].eta, 0);
+  }
+
+  function testFuzz_EmitsRollbackExecuted(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+    uint256 _rollbackId = _proposeAndQueueRollback(_targets, _values, _calldatas, _description);
+
+    vm.expectEmit(true, true, true, true);
+    emit UpgradeRegressionManager.RollbackExecuted(_rollbackId);
+
+    vm.warp(block.timestamp + timelockTarget.delay());
+    vm.prank(guardian);
+    upgradeRegressionManager.execute(_targets, _values, _calldatas, _description);
+  }
+
+  function testFuzz_RemovesFromRollbackExecutableAtQueue(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+    uint256 _rollbackId = _proposeAndQueueRollback(_targets, _values, _calldatas, _description);
+
+    assertEq(upgradeRegressionManager.rollbackExecutableAt(_rollbackId), block.timestamp + timelockTarget.delay());
+    vm.warp(block.timestamp + timelockTarget.delay());
+    vm.prank(guardian);
+    upgradeRegressionManager.execute(_targets, _values, _calldatas, _description);
+
+    assertEq(upgradeRegressionManager.rollbackExecutableAt(_rollbackId), 0);
+  }
+
+  function testFuzz_RevertIf_RollbackExecutionEtaHasNotPassed(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+    uint256 _rollbackId = _proposeAndQueueRollback(_targets, _values, _calldatas, _description);
+
+    vm.warp(block.timestamp + timelockTarget.delay() - 1);
+    vm.expectRevert(
+      abi.encodeWithSelector(UpgradeRegressionManager.UpgradeRegressionManager__ExecutionTooEarly.selector, _rollbackId)
+    );
+    vm.prank(guardian);
+    upgradeRegressionManager.execute(_targets, _values, _calldatas, _description);
+  }
+
+  function testFuzz_RevertIf_RollbackWasNeverProposed(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+    uint256 _computedRollbackId = upgradeRegressionManager.getRollbackId(_targets, _values, _calldatas, _description);
+
+    vm.warp(block.timestamp + timelockTarget.delay());
+
+    vm.expectRevert(
+      abi.encodeWithSelector(UpgradeRegressionManager.UpgradeRegressionManager__NotQueued.selector, _computedRollbackId)
+    );
+    vm.prank(guardian);
+    upgradeRegressionManager.execute(_targets, _values, _calldatas, _description);
+  }
+
+  function testFuzz_RevertIf_RollbackWasAlreadyCanceled(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+    uint256 _rollbackId = _proposeAndQueueRollback(_targets, _values, _calldatas, _description);
+
+    vm.prank(guardian);
+    upgradeRegressionManager.cancel(_targets, _values, _calldatas, _description);
+
+    vm.warp(block.timestamp + timelockTarget.delay());
+
+    vm.expectRevert(
+      abi.encodeWithSelector(UpgradeRegressionManager.UpgradeRegressionManager__NotQueued.selector, _rollbackId)
+    );
+    vm.prank(guardian);
+    upgradeRegressionManager.execute(_targets, _values, _calldatas, _description);
+  }
+
+  function testFuzz_RevertIf_RollbackWasAlreadyExecuted(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+    uint256 _rollbackId = _proposeAndQueueRollback(_targets, _values, _calldatas, _description);
+
+    vm.warp(block.timestamp + timelockTarget.delay());
+    vm.prank(guardian);
+    upgradeRegressionManager.execute(_targets, _values, _calldatas, _description);
+
+    vm.expectRevert(
+      abi.encodeWithSelector(UpgradeRegressionManager.UpgradeRegressionManager__NotQueued.selector, _rollbackId)
+    );
+    vm.prank(guardian);
+    upgradeRegressionManager.execute(_targets, _values, _calldatas, _description);
+  }
+
+  function testFuzz_RevertIf_CallerIsNotGuardian(
+    address _caller,
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+    vm.assume(_caller != guardian);
+
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__Unauthorized.selector);
+    vm.prank(_caller);
+    upgradeRegressionManager.execute(_targets, _values, _calldatas, _description);
+  }
+
+  function testFuzz_RevertIf_MismatchedParameters(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    uint256[] memory _valuesMismatch = new uint256[](1);
+    bytes[] memory _calldatasMismatch = new bytes[](1);
+
+    _proposeAndQueueRollback(_targets, _values, _calldatas, _description);
+
+    vm.warp(block.timestamp + timelockTarget.delay());
+
+    vm.startPrank(guardian);
+    // target and values length mismatch
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__MismatchedParameters.selector);
+    upgradeRegressionManager.execute(_targets, _valuesMismatch, _calldatas, _description);
+
+    // target and calldatas length mismatch
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__MismatchedParameters.selector);
+    upgradeRegressionManager.execute(_targets, _values, _calldatasMismatch, _description);
+
+    vm.stopPrank();
+  }
+}
+
+contract IsRollbackEligibleToQueue is UpgradeRegressionManagerTest {
+  function test_ReturnsFalseIfRollbackDoesNotExist(uint256 _rollbackId) external view {
+    assertEq(upgradeRegressionManager.isRollbackEligibleToQueue(_rollbackId), false);
+  }
+
+  function test_ReturnsFalseIfRollbackQueueExpiryWindowHasPassed(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    vm.prank(admin);
+    uint256 _rollbackId = upgradeRegressionManager.propose(_targets, _values, _calldatas, _description);
+    vm.warp(block.timestamp + rollbackQueueWindow + 1);
+    assertEq(upgradeRegressionManager.isRollbackEligibleToQueue(_rollbackId), false);
+  }
+
+  function test_ReturnsTrueIfRollbackQueueExpiryWindowHasNotPassed(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    vm.prank(admin);
+    uint256 _rollbackId = upgradeRegressionManager.propose(_targets, _values, _calldatas, _description);
+
+    assertEq(upgradeRegressionManager.isRollbackEligibleToQueue(_rollbackId), true);
+  }
+}
+
+contract IsRollbackReadyToExecute is UpgradeRegressionManagerTest {
+  function test_ReturnsFalseIfRollbackDoesNotExist(uint256 _rollbackId) external view {
+    assertEq(upgradeRegressionManager.isRollbackReadyToExecute(_rollbackId), false);
+  }
+
+  function test_ReturnsFalseIfRollbackExecutionDelayHasNotPassed(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    vm.prank(admin);
+    uint256 _rollbackId = upgradeRegressionManager.propose(_targets, _values, _calldatas, _description);
+
+    vm.prank(guardian);
+    upgradeRegressionManager.queue(_targets, _values, _calldatas, _description);
+
+    assertEq(upgradeRegressionManager.isRollbackReadyToExecute(_rollbackId), false);
+  }
+
+  function test_ReturnsTrueIfRollbackExecutionDelayHasPassed(
+    address[2] memory _targetsFixed,
+    uint256[2] memory _valuesFixed,
+    bytes[2] memory _calldatasFixed,
+    string memory _description
+  ) external {
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas) =
+      toDynamicArrays(_targetsFixed, _valuesFixed, _calldatasFixed);
+
+    vm.prank(admin);
+    uint256 _rollbackId = upgradeRegressionManager.propose(_targets, _values, _calldatas, _description);
+
+    vm.prank(guardian);
+    upgradeRegressionManager.queue(_targets, _values, _calldatas, _description);
+
+    vm.warp(block.timestamp + timelockTarget.delay());
+
+    assertEq(upgradeRegressionManager.isRollbackReadyToExecute(_rollbackId), true);
+  }
+}
+
+contract SetGuardian is UpgradeRegressionManagerTest {
+  function test_SetsGuardian(address _newGuardian) external {
+    _assumeSafeGuardian(_newGuardian);
+
+    vm.prank(admin);
+    upgradeRegressionManager.setGuardian(_newGuardian);
+
+    assertEq(upgradeRegressionManager.guardian(), _newGuardian);
+  }
+
+  function testFuzz_EmitsGuardianSet(address _newGuardian) external {
+    _assumeSafeGuardian(_newGuardian);
+
+    vm.expectEmit(true, true, true, true);
+    emit UpgradeRegressionManager.GuardianSet(guardian, _newGuardian);
+    vm.prank(admin);
+    upgradeRegressionManager.setGuardian(_newGuardian);
+  }
+
+  function testFuzz_RevertIf_CallerIsNotAdmin(address _caller, address _newGuardian) external {
+    _assumeSafeGuardian(_newGuardian);
+    vm.assume(_caller != admin);
+
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__Unauthorized.selector);
+    vm.prank(_caller);
+    upgradeRegressionManager.setGuardian(_newGuardian);
+  }
+
+  function test_RevertIf_NewGuardianIsZeroAddress() external {
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__InvalidAddress.selector);
+    vm.prank(admin);
+    upgradeRegressionManager.setGuardian(address(0));
+  }
+}
+
+contract SetRollbackQueueWindow is UpgradeRegressionManagerTest {
+  function test_SetsRollbackQueueWindow(uint256 _newRollbackQueueWindow) external {
+    _newRollbackQueueWindow = _boundToRealisticRollbackQueueWindow(_newRollbackQueueWindow);
+
+    vm.prank(admin);
+    upgradeRegressionManager.setRollbackQueueWindow(_newRollbackQueueWindow);
+
+    assertEq(upgradeRegressionManager.rollbackQueueWindow(), _newRollbackQueueWindow);
+  }
+
+  function testFuzz_EmitsRollbackQueueWindowSet(uint256 _newRollbackQueueWindow) external {
+    _newRollbackQueueWindow = _boundToRealisticRollbackQueueWindow(_newRollbackQueueWindow);
+
+    vm.expectEmit(true, true, true, true);
+    emit UpgradeRegressionManager.RollbackQueueWindowSet(rollbackQueueWindow, _newRollbackQueueWindow);
+    vm.prank(admin);
+    upgradeRegressionManager.setRollbackQueueWindow(_newRollbackQueueWindow);
+  }
+
+  function testFuzz_RevertIf_CallerIsNotAdmin(address _caller, uint256 _newRollbackQueueWindow) external {
+    vm.assume(_caller != admin);
+
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__Unauthorized.selector);
+    vm.prank(_caller);
+    upgradeRegressionManager.setRollbackQueueWindow(_newRollbackQueueWindow);
+  }
+
+  function test_RevertIf_NewRollbackQueueWindowIsZero() external {
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__InvalidRollbackQueueWindow.selector);
+    vm.prank(admin);
+    upgradeRegressionManager.setRollbackQueueWindow(0);
+  }
+}
+
+contract SetAdmin is UpgradeRegressionManagerTest {
+  function test_SetsAdmin(address _newAdmin) external {
+    _assumeSafeAdmin(_newAdmin);
+
+    vm.prank(admin);
+    upgradeRegressionManager.setAdmin(_newAdmin);
+
+    assertEq(upgradeRegressionManager.admin(), _newAdmin);
+  }
+
+  function testFuzz_EmitsAdminSet(address _newAdmin) external {
+    _assumeSafeAdmin(_newAdmin);
+
+    vm.expectEmit(true, true, true, true);
+    emit UpgradeRegressionManager.AdminSet(admin, _newAdmin);
+    vm.prank(admin);
+    upgradeRegressionManager.setAdmin(_newAdmin);
+  }
+
+  function testFuzz_RevertIf_CallerIsNotAdmin(address _caller, address _newAdmin) external {
+    _assumeSafeAdmin(_newAdmin);
+    vm.assume(_caller != admin);
+
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__Unauthorized.selector);
+    vm.prank(_caller);
+    upgradeRegressionManager.setAdmin(_newAdmin);
+  }
+
+  function test_RevertIf_NewAdminIsZeroAddress() external {
+    vm.expectRevert(UpgradeRegressionManager.UpgradeRegressionManager__InvalidAddress.selector);
+    vm.prank(admin);
+    upgradeRegressionManager.setAdmin(address(0));
+  }
+}
+
+contract GetRollbackId is UpgradeRegressionManagerTest {
+  function test_ReturnsRollbackId(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) external view {
+    uint256 _rollbackId = upgradeRegressionManager.getRollbackId(_targets, _values, _calldatas, _description);
+
+    assertEq(_rollbackId, uint256(keccak256(abi.encode(_targets, _values, _calldatas, _description))));
+  }
+}
+
+/// @dev Internal Functions Skipped as these are not intended to be inherited by other contracts
+contract _revertIfNotAdmin is UpgradeRegressionManagerTest {}
+
+contract _revertIfNotGuardian is UpgradeRegressionManagerTest {}
+
+contract _revertIfMismatchedParameters is UpgradeRegressionManagerTest {}
+
+contract _setGuardian is UpgradeRegressionManagerTest {}
+
+contract _setRollbackQueueWindow is UpgradeRegressionManagerTest {}
+
+contract _setAdmin is UpgradeRegressionManagerTest {}

--- a/test/mocks/MockTimelockTarget.sol
+++ b/test/mocks/MockTimelockTarget.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {ITimelockTarget} from "../../src/interfaces/ITimelockTarget.sol";
+
+contract MockTimelockTarget is ITimelockTarget {
+  // Struct for tracking function call parameters
+  struct TimelockTransactionCall {
+    address target;
+    uint256 value;
+    string signature;
+    bytes data;
+    uint256 eta;
+    bool called;
+  }
+
+  // Storage for tracking the most recent call to each function
+  TimelockTransactionCall[] internal _lastParam__queueTransactions__;
+  TimelockTransactionCall[] internal _lastParam__cancelTransactions__;
+  TimelockTransactionCall[] internal _lastParam__executeTransactions__;
+
+  // Mock delay for testing
+  uint256 public delay = 1 days;
+
+  /// @dev Mock implementation that tracks parameters and returns mock value
+  function queueTransaction(address target, uint256 value, string calldata signature, bytes calldata data, uint256 eta)
+    external
+    returns (bytes memory)
+  {
+    // Track the call parameters
+    _lastParam__queueTransactions__.push(
+      TimelockTransactionCall({target: target, value: value, signature: signature, data: data, eta: eta, called: true})
+    );
+
+    return abi.encode(_lastParam__queueTransactions__.length);
+  }
+
+  /// @dev Mock implementation that tracks parameters
+  function cancelTransaction(address target, uint256 value, string memory signature, bytes memory data, uint256 eta)
+    external
+  {
+    // Track the call parameters
+    _lastParam__cancelTransactions__.push(
+      TimelockTransactionCall({target: target, value: value, signature: signature, data: data, eta: eta, called: true})
+    );
+  }
+
+  /// @dev Mock implementation that tracks parameters and returns mock value
+  function executeTransaction(address target, uint256 value, string memory signature, bytes memory data, uint256 eta)
+    external
+    payable
+    override
+    returns (bytes memory)
+  {
+    // Track the call parameters
+    _lastParam__executeTransactions__.push(
+      TimelockTransactionCall({target: target, value: value, signature: signature, data: data, eta: eta, called: true})
+    );
+
+    return abi.encode(_lastParam__executeTransactions__.length);
+  }
+
+  // Helper function to clear all tracked call data
+  function clearCallHistory() external {
+    delete _lastParam__queueTransactions__;
+    delete _lastParam__cancelTransactions__;
+    delete _lastParam__executeTransactions__;
+  }
+
+  // Helper function to get the last queue transaction call as a struct
+  function lastParam__queueTransactions__() external view returns (TimelockTransactionCall[] memory) {
+    return _lastParam__queueTransactions__;
+  }
+
+  // Helper function to get the last execute transaction call as a struct
+  function lastParam__executeTransactions__() external view returns (TimelockTransactionCall[] memory) {
+    return _lastParam__executeTransactions__;
+  }
+
+  // Helper function to get the last cancel transaction call as a struct
+  function lastParam__cancelTransactions__() external view returns (TimelockTransactionCall[] memory) {
+    return _lastParam__cancelTransactions__;
+  }
+}


### PR DESCRIPTION
### Description

Implement UpgradeRegressionManager and unit tests
This contract manages the lifecycle of rollback proposals, allowing the admin to propose, and the guardian to queue, cancel, or execute rollback transactions to  a target timelock contract ( such as TimelockMultiAdminShim) 

**Lifecycle**
- Admin proposes rollback transactions.
- Guardian queues them for execution within a specified window which is decided when the rollback is proposed
- Guardian later executes or cancels the queued rollback.
- On queuing / cancelling / executing, the transactions are sent to TimelockTarget.

**Contents Added in this PR**
- [x] Spike Shim
- [x] Implement Shim contract with slim interface
- [x] NatSpec
- [x] Unit Fuzzing with scopelint


Refs https://github.com/ScopeLift/governance-rollback/issues/4