### PR TITLE
feat/5: track rollback state

### DIFF
--- a/src/interfaces/IUpgradeRegressionManager.sol
+++ b/src/interfaces/IUpgradeRegressionManager.sol
@@ -1,8 +1,26 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
+// External Libraries
+import {IGovernor} from "@openzeppelin/contracts/governance/IGovernor.sol";
+
 // Internal Libraries
 import {ITimelockTarget} from "interfaces/ITimelockTarget.sol";
+
+/// @notice Struct to store rollback data.
+/// @param queueExpiresAt The timestamp before which the rollback must be queued for execution.
+/// @param executableAt The timestamp after which the rollback can be executed.
+/// @param executed Whether the rollback has been executed.
+/// @param canceled Whether the rollback has been canceled.
+/// @dev executed and canceled are mutually exclusive - both cannot be true
+///      queueExpiresAt must be > block.timestamp when rollback is proposed
+///      executableAt must be > block.timestamp when rollback is queued
+struct Rollback {
+  uint48 queueExpiresAt;
+  uint48 executableAt;
+  bool executed;
+  bool canceled;
+}
 
 interface IUpgradeRegressionManager {
   /*///////////////////////////////////////////////////////////////
@@ -17,17 +35,11 @@ interface IUpgradeRegressionManager {
 
   function rollbackQueueWindow() external view returns (uint256);
 
-  function rollbackQueueExpiresAt(uint256 _rollbackId) external view returns (uint256);
-
-  function rollbackExecutableAt(uint256 _rollbackId) external view returns (uint256);
+  function getRollback(uint256 _rollbackId) external view returns (Rollback memory);
 
   /*///////////////////////////////////////////////////////////////
                      External Functions 
   //////////////////////////////////////////////////////////////*/
-
-  function isRollbackEligibleToQueue(uint256 _rollbackId) external view returns (bool);
-
-  function isRollbackReadyToExecute(uint256 _rollbackId) external view returns (bool);
 
   function propose(
     address[] memory _targets,
@@ -73,4 +85,6 @@ interface IUpgradeRegressionManager {
     bytes[] memory _calldatas,
     string memory _description
   ) external view returns (uint256 _rollbackId);
+
+  function state(uint256 _rollbackId) external view returns (IGovernor.ProposalState);
 }

--- a/test/TimelockMultiAdminShim.unit.t.sol
+++ b/test/TimelockMultiAdminShim.unit.t.sol
@@ -514,16 +514,3 @@ contract Fallback is TimelockMultiAdminShimTest {
     assertTrue(success);
   }
 }
-
-/// @dev Internal Functions Skipped as these are not intended to be inherited by other contracts
-contract _revertIfCannotQueue is TimelockMultiAdminShimTest {}
-
-contract _revertIfNotAdminOrExecutor is TimelockMultiAdminShimTest {}
-
-contract _revertIfNotAdmin is TimelockMultiAdminShimTest {}
-
-contract _revertIfNotTimelock is TimelockMultiAdminShimTest {}
-
-contract _setAdmin is TimelockMultiAdminShimTest {}
-
-contract _revertIfInvalidExecutor is TimelockMultiAdminShimTest {}


### PR DESCRIPTION
**Description**

Added a method state to be able track the state of an rollback proposal to make it easier for tally to build a UI for this.
Additionally reused the same function within the contract to ensure correct state transition


- add new types folder to sore struct and enum
- add enum GovernanceTypes.ProposalState
- add struct GovernanceTypes.Rollback
- add _rollbacks to track rollbacks
- add state(rollbackId) which returns state of a rollback
- update propose,queue,execute and cancel to use state and _rollbacks
- remove isRollbackReadyToExecute, isRollbackEligibleToQueue in favour of state
- update unit and integration test

Fixes https://github.com/ScopeLift/governance-rollback/issues/8


```
├── state
│   ├──  Rollback That Is Proposed And Within Expiry Window Is In Pending State
│   ├──  Rollback That Is Proposed And After Expiry Window Is In Expired State
│   ├──  Rollback That Is Proposed And At Exact Expiration Time Is Expired
│   ├──  Rollback That Is Queued But Before Executable At Window Is In Queued State
│   ├──  Rollback That Is Queued But After Executable At Window Is In Active State
│   ├──  Rollback That Is Queued And At Exact Execution Time Is Active
│   ├──  Rollback That Is Executed Is In Executed State
│   ├──  Rollback That Is Canceled Is In Canceled State
│   └──  Rollback That Is Not Proposed Is In Unknown State
```