### PR TITLE
feat/6: add MIN_ROLLBACK_QUEUEABLE_DURATION to URM

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ The Governance Emergency Rollback system provides a secure, flexible, and backwa
 
 The architecture follows established patterns from OpenZeppelin Governor, ensuring consistency and familiarity for developers and auditors. The modular design allows for future enhancements while maintaining the core security model.
 
+**[Governance Upgrade Impact Analysis](docs/GOVERNANCE_UPGRADE_IMPACT.md)** - Detailed analysis of how the governance upgrade affects existing proposals at different lifecycle stages
+
 ## Development
 
 These contracts were built and tested with care by the team at [ScopeLift](https://scopelift.co).

--- a/docs/GOVERNANCE_UPGRADE_IMPACT.md
+++ b/docs/GOVERNANCE_UPGRADE_IMPACT.md
@@ -1,0 +1,69 @@
+# Governance Upgrade Impact Analysis
+
+> **⚠️ Important**: This document analyzes the impact of upgrading to the TimelockMultiAdminShim on existing governance proposals at various stages of their lifecycle.
+
+## Overview
+
+When the proposal to upgrade the DAO governance contracts goes live (adopting the TimelockMultiAdminShim), existing proposals may be at different stages of their lifecycle. This document analyzes how these proposals will be affected and provides integration tests to verify the expected behavior.
+
+## Upgrade Architecture
+
+The upgrade involves:
+
+1. **Deploying:** 
+    - `TimelockMultiAdminShim` (Shim) with  
+      - `admin` = Governor
+      - `timelock` = Compound Timelock
+      - `executor` = URM
+    -  `UpgradeRegressionManager` (URM) with 
+       - `admin` = Compound Timelock
+       - `guardian` = Compound trusted multisig
+       - `target` = `TimelockMultiAdminShim`
+2. **Proposal & Executing an Upgrade:** 
+   - Set Governor's `timelock` to `TimelockMultiAdminShim`
+   - Set Timelock’s `admin` to `TimelockMultiAdminShim`
+
+After this, all `queue()`, `execute()`, `cancel()` calls go through the Shim — even for proposals queued before the upgrade.
+
+## Lifecycle Scenarios
+
+### 1. **Proposed but Not Yet Active**
+- **State**: Proposal is created, still in proposal delay period
+- **Effect**: **No Impact** ✅
+- **Reason**: Shim is not involved until the queue() phase. Governor handles proposal lifecycle normally.
+
+### 2. **Voting In Progress**
+- **State**: Proposal is active and undergoing voting.
+- **Effect**: **No Impact** ✅
+- **Reason**: Voting is governed by the Governor, not the timelock. Shim is not involved yet.
+
+
+### 3. **Succeeded but Not Yet Queued**
+- **State**: Voting complete, proposal has succeeded, but queue() not yet called.
+- **Effect**: **No Impact** ✅
+- **Change**: queue() now routes through the Shim, which forwards to the Timelock with the same same proposal hash
+
+### 4. **Queued Before Upgrade**
+- **State**: Proposal was already queued in Timelock before the upgrade.
+- **Effect**: **Compatible** ✅
+- **Change**: execute() must now go through the Shim, since the Governor’s timelock is now the Shim.
+
+
+### 5. **Queued After Upgrade**
+- **State**: Proposal is queued after the upgrade and is still in the timelock delay
+- **Effect**: **Expected behavior** ✅
+- **Changes**: Both `queue()` and `execute()` go through Shim → Timelock.
+
+## Integration Test Matrix
+
+| Scenario                       | Proposal State | Action Pre-Upgrade  | Action Post-Upgrade | Shim Used? | Expected |
+| ------------------------------ | -------------- | ------------------- | ------------------- | ---------- | -------- |
+| Proposal not yet active        | `Pending`      | Governor only       | Governor            | ❌          | ✅ Works  |
+| Proposal in voting             | `Active`       | Governor only       | Governor            | ❌          | ✅ Works  |
+| Proposal succeeded, not queued | `Succeeded`    | Governor            | Governor → Shim     | ✅          | ✅ Works  |
+| Proposal queued before upgrade | `Queued`       | Governor → Timelock | Governor → Shim     | ✅          | ✅ Works  |
+| Proposal queued after upgrade  | `Queued`       | —                   | Governor → Shim     | ✅          | ✅ Works  |
+
+These scenarios are covered in the integration test suite at [GovernanceUpgradeImpact.integration.t.sol](../test/GovernanceUpgradeImpact.integration.t.sol)
+
+The governance upgrade to `TimelockMultiAdminShim` is designed to be fully **backward compatible**, ensuring that all existing proposals—regardless of their current stage—continue to function as expected.

--- a/script/1_DeployShimAndURM.s.sol
+++ b/script/1_DeployShimAndURM.s.sol
@@ -41,7 +41,8 @@ contract DeployShimAndURM is Script, BaseLogger, DeployInput {
       ITimelockTarget(address(timelockMultiAdminShim)), // Target is the shim address
       COMPOUND_TIMELOCK, // admin is the compound timelock
       GUARDIAN, // Address that can queue, cancel and execute rollback
-      ROLLBACK_QUEUE_WINDOW // Time window within which a rollback can be queued after it is proposed by admin
+      ROLLBACK_QUEUEABLE_DURATION, // Duration after a rollback proposal during which it can be queued for execution
+      MIN_ROLLBACK_QUEUEABLE_DURATION // Lower bound enforced on the rollback queueable duration
     );
 
     vm.stopBroadcast();

--- a/script/DeployInput.sol
+++ b/script/DeployInput.sol
@@ -14,8 +14,11 @@ contract DeployInput {
   // https://docs.google.com/document/d/19-GFwd34UlPHIx-AjlGlI3BQcWq71UKe/
   address public constant GUARDIAN = 0xbbf3f1421D886E9b2c5D716B5192aC998af2012c;
 
-  // Time window within which a rollback can be queued after it is proposed by admin
-  uint256 public constant ROLLBACK_QUEUE_WINDOW = 4 weeks;
+  // Time duration during which a proposed rollback can be queued for execution.
+  uint256 public constant ROLLBACK_QUEUEABLE_DURATION = 4 weeks;
+
+  // Lower bound for rollback queue duration (set to same value as COMPOUND_GOVERNOR.votingDelay)
+  uint256 public constant MIN_ROLLBACK_QUEUEABLE_DURATION = 13_140;
 
   // Deployed TimelockMultiAdminShim contract
   address public TIMELOCK_MULTI_ADMIN_SHIM = address(0);

--- a/src/contracts/UpgradeRegressionManager.sol
+++ b/src/contracts/UpgradeRegressionManager.sol
@@ -32,8 +32,8 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
   /// @notice Thrown when a rollback does not exist.
   error UpgradeRegressionManager__NonExistentRollback(uint256 rollbackId);
 
-  /// @notice Thrown when an invalid rollback queue window is provided.
-  error UpgradeRegressionManager__InvalidRollbackQueueWindow();
+  /// @notice Thrown when an invalid rollback queueable duration is provided.
+  error UpgradeRegressionManager__InvalidRollbackQueueableDuration();
 
   /// @notice Thrown when the lengths of the parameters do not match.
   error UpgradeRegressionManager__MismatchedParameters();
@@ -91,10 +91,10 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
   /// @param newGuardian The new guardian.
   event GuardianSet(address indexed oldGuardian, address indexed newGuardian);
 
-  /// @notice Emitted when the rollback queue window is set.
-  /// @param oldRollbackQueueWindow The old rollback queue window.
-  /// @param newRollbackQueueWindow The new rollback queue window.
-  event RollbackQueueWindowSet(uint256 oldRollbackQueueWindow, uint256 newRollbackQueueWindow);
+  /// @notice Emitted when the rollback queueable duration is set.
+  /// @param oldRollbackQueueableDuration The old rollback queueable duration.
+  /// @param newRollbackQueueableDuration The new rollback queueable duration.
+  event RollbackQueueableDurationSet(uint256 oldRollbackQueueableDuration, uint256 newRollbackQueueableDuration);
 
   /// @notice Emitted when the admin is set.
   /// @param oldAdmin The old admin.
@@ -108,14 +108,17 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
   /// @notice Target for timelocked execution of rollback transactions.
   ITimelockTarget public immutable TARGET;
 
+  /// @notice The lower bound enforced for the rollbackQueueableDuration setting.
+  uint256 public immutable MIN_ROLLBACK_QUEUEABLE_DURATION;
+
   /// @notice Address that manages this contract.
   address public admin;
 
   /// @notice Address that can execute rollback transactions.
   address public guardian;
 
-  /// @notice Time window after a rollback is proposed during which it can be queued for execution.
-  uint256 public rollbackQueueWindow;
+  /// @notice The duration after a rollback is proposed during which it remains eligible to be queued for execution.
+  uint256 public rollbackQueueableDuration;
 
   /// @notice Rollback id to rollback data.
   mapping(uint256 rollbackId => Rollback) private rollbacks;
@@ -128,17 +131,29 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
   /// @param _target The target for timelocked execution of rollback transactions.
   /// @param _admin The address that manages this contract.
   /// @param _guardian The address that can execute rollback transactions.
-  /// @param _rollbackQueueWindow The time window after a rollback is proposed during which it can be queued for
+  /// @param _rollbackQueueableDuration The duration within which a proposed rollback remains eligible to be queued for
   /// execution.
-  constructor(ITimelockTarget _target, address _admin, address _guardian, uint256 _rollbackQueueWindow) {
+  /// @param _minRollbackQueueableDuration The lower bound enforced for the rollbackQueueableDuration setting.
+  constructor(
+    ITimelockTarget _target,
+    address _admin,
+    address _guardian,
+    uint256 _rollbackQueueableDuration,
+    uint256 _minRollbackQueueableDuration
+  ) {
+    if (_minRollbackQueueableDuration == 0) {
+      revert UpgradeRegressionManager__InvalidRollbackQueueableDuration();
+    }
+
     if (address(_target) == address(0)) {
       revert UpgradeRegressionManager__InvalidAddress();
     }
 
     TARGET = _target;
+    MIN_ROLLBACK_QUEUEABLE_DURATION = _minRollbackQueueableDuration;
 
     _setAdmin(_admin);
-    _setRollbackQueueWindow(_rollbackQueueWindow);
+    _setRollbackQueueableDuration(_rollbackQueueableDuration);
     _setGuardian(_guardian);
   }
 
@@ -181,7 +196,7 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
     }
 
     // Set the time before which the rollback can be queued for execution.
-    uint256 _expiresAt = block.timestamp + rollbackQueueWindow;
+    uint256 _expiresAt = block.timestamp + rollbackQueueableDuration;
     rollback.queueExpiresAt = SafeCast.toUint48(_expiresAt);
 
     emit RollbackProposed(_rollbackId, _expiresAt, _targets, _values, _calldatas, _description);
@@ -321,12 +336,12 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
     _setGuardian(_newGuardian);
   }
 
-  /// @notice Sets the rollback queue window.
-  /// @param _newRollbackQueueWindow The new rollback queue window.
+  /// @notice Sets the rollback queueable duration.
+  /// @param _newRollbackQueueableDuration The new rollback queueable duration.
   /// @dev Can only be called by the admin.
-  function setRollbackQueueWindow(uint256 _newRollbackQueueWindow) external {
+  function setRollbackQueueableDuration(uint256 _newRollbackQueueableDuration) external {
     _revertIfNotAdmin();
-    _setRollbackQueueWindow(_newRollbackQueueWindow);
+    _setRollbackQueueableDuration(_newRollbackQueueableDuration);
   }
 
   /// @notice Sets the admin.
@@ -406,15 +421,15 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
     guardian = _newGuardian;
   }
 
-  /// @notice Utility function to set the rollback queue window.
-  /// @param _newRollbackQueueWindow The new rollback queue window.
-  function _setRollbackQueueWindow(uint256 _newRollbackQueueWindow) internal {
-    if (_newRollbackQueueWindow == 0) {
-      revert UpgradeRegressionManager__InvalidRollbackQueueWindow();
+  /// @notice Utility function to set the rollback queueable duration.
+  /// @param _newRollbackQueueableDuration The new rollback queueable duration.
+  function _setRollbackQueueableDuration(uint256 _newRollbackQueueableDuration) internal {
+    if (_newRollbackQueueableDuration < MIN_ROLLBACK_QUEUEABLE_DURATION) {
+      revert UpgradeRegressionManager__InvalidRollbackQueueableDuration();
     }
 
-    emit RollbackQueueWindowSet(rollbackQueueWindow, _newRollbackQueueWindow);
-    rollbackQueueWindow = _newRollbackQueueWindow;
+    emit RollbackQueueableDurationSet(rollbackQueueableDuration, _newRollbackQueueableDuration);
+    rollbackQueueableDuration = _newRollbackQueueableDuration;
   }
 
   /// @notice Utility function to set the admin.

--- a/src/contracts/UpgradeRegressionManager.sol
+++ b/src/contracts/UpgradeRegressionManager.sol
@@ -117,7 +117,8 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
   /// @notice Address that can execute rollback transactions.
   address public guardian;
 
-  /// @notice The duration after a rollback is proposed during which it remains eligible to be queued for execution.
+  /// @notice The duration after a rollback is proposed during which it remains eligible to be queued for execution (in
+  /// seconds).
   uint256 public rollbackQueueableDuration;
 
   /// @notice Rollback id to rollback data.
@@ -132,8 +133,9 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
   /// @param _admin The address that manages this contract.
   /// @param _guardian The address that can execute rollback transactions.
   /// @param _rollbackQueueableDuration The duration within which a proposed rollback remains eligible to be queued for
-  /// execution.
-  /// @param _minRollbackQueueableDuration The lower bound enforced for the rollbackQueueableDuration setting.
+  /// execution (in seconds).
+  /// @param _minRollbackQueueableDuration The lower bound enforced for the rollbackQueueableDuration setting (in
+  /// seconds).
   constructor(
     ITimelockTarget _target,
     address _admin,
@@ -337,7 +339,7 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
   }
 
   /// @notice Sets the rollback queueable duration.
-  /// @param _newRollbackQueueableDuration The new rollback queueable duration.
+  /// @param _newRollbackQueueableDuration The new rollback queueable duration in seconds.
   /// @dev Can only be called by the admin.
   function setRollbackQueueableDuration(uint256 _newRollbackQueueableDuration) external {
     _revertIfNotAdmin();
@@ -422,7 +424,7 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
   }
 
   /// @notice Utility function to set the rollback queueable duration.
-  /// @param _newRollbackQueueableDuration The new rollback queueable duration.
+  /// @param _newRollbackQueueableDuration The new rollback queueable duration (in seconds).
   function _setRollbackQueueableDuration(uint256 _newRollbackQueueableDuration) internal {
     if (_newRollbackQueueableDuration < MIN_ROLLBACK_QUEUEABLE_DURATION) {
       revert UpgradeRegressionManager__InvalidRollbackQueueableDuration();

--- a/src/interfaces/IUpgradeRegressionManager.sol
+++ b/src/interfaces/IUpgradeRegressionManager.sol
@@ -33,7 +33,7 @@ interface IUpgradeRegressionManager {
 
   function guardian() external view returns (address);
 
-  function rollbackQueueWindow() external view returns (uint256);
+  function rollbackQueueableDuration() external view returns (uint256);
 
   function getRollback(uint256 _rollbackId) external view returns (Rollback memory);
 
@@ -71,7 +71,7 @@ interface IUpgradeRegressionManager {
 
   function setGuardian(address _newGuardian) external;
 
-  function setRollbackQueueWindow(uint256 _newRollbackQueueWindow) external;
+  function setRollbackQueueableDuration(uint256 _newRollbackQueueableDuration) external;
 
   function setAdmin(address _newAdmin) external;
 

--- a/test/DeployScripts.integration.t.sol
+++ b/test/DeployScripts.integration.t.sol
@@ -117,7 +117,7 @@ contract DeployScriptsIntegrationTest is Test, DeployInput {
     assertEq(address(upgradeRegressionManager.TARGET()), address(timelockMultiAdminShim));
     assertEq(upgradeRegressionManager.admin(), COMPOUND_TIMELOCK);
     assertEq(upgradeRegressionManager.guardian(), GUARDIAN);
-    assertEq(upgradeRegressionManager.rollbackQueueWindow(), ROLLBACK_QUEUE_WINDOW);
+    assertEq(upgradeRegressionManager.rollbackQueueableDuration(), ROLLBACK_QUEUEABLE_DURATION);
 
     _step2__proposeTransferTimelockAdminToShim(TIMELOCK_MULTI_ADMIN_SHIM);
 

--- a/test/DeployScripts.integration.t.sol
+++ b/test/DeployScripts.integration.t.sol
@@ -70,6 +70,21 @@ contract DeployScriptsIntegrationTest is Test, DeployInput {
     return (address(timelockMultiAdminShim), upgradeRegressionManager, governorHelper, proposer);
   }
 
+  function onlyDeployShimAndURM() external returns (address, UpgradeRegressionManager, CompoundGovernorHelper, address) {
+    setUp();
+    _step1_deployShimAndURM();
+    return (address(timelockMultiAdminShim), upgradeRegressionManager, governorHelper, proposer);
+  }
+
+  function onlyProposeTransferTimelockAdminToShim(address _timelockMultiAdminShim)
+    external
+    returns (address, UpgradeRegressionManager, CompoundGovernorHelper, address)
+  {
+    _step2__proposeTransferTimelockAdminToShim(_timelockMultiAdminShim);
+    _step3_acceptAdminFromShim(_timelockMultiAdminShim);
+    return (address(timelockMultiAdminShim), upgradeRegressionManager, governorHelper, proposer);
+  }
+
   /*///////////////////////////////////////////////////////////////
                       Test Functions
   //////////////////////////////////////////////////////////////*/
@@ -96,7 +111,7 @@ contract DeployScriptsIntegrationTest is Test, DeployInput {
     CompoundGovernorHelper.Proposal memory proposal =
       CompoundGovernorHelper.Proposal(targets, values, calldatas, description);
 
-    governorHelper.submitPassQueueAndExecuteProposal(proposer, proposal);
+    governorHelper.submitPassQueueAndExecuteProposalWithRoll(proposer, proposal);
   }
 
   function _step3_acceptAdminFromShim(address _timelockMultiAdminShim) internal {

--- a/test/GovernanceUpgradeImpact.integration.t.sol
+++ b/test/GovernanceUpgradeImpact.integration.t.sol
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+// External imports
+import {Test} from "forge-std/Test.sol";
+import {console2} from "forge-std/console2.sol";
+// Internal imports
+import {DeployScriptsIntegrationTest} from "test/DeployScripts.integration.t.sol";
+import {FakeProtocolContract} from "test/fakes/FakeProtocolContract.sol";
+import {CompoundGovernorHelper} from "test/helpers/CompoundGovernorHelper.sol";
+import {FakeProtocolRollbackTestHelper} from "test/fakes/FakeProtocolRollbackTestHelper.sol";
+import {UpgradeRegressionManager} from "src/contracts/UpgradeRegressionManager.sol";
+import {TimelockMultiAdminShim} from "src/contracts/TimelockMultiAdminShim.sol";
+import {DeployInput} from "script/DeployInput.sol";
+import {ProposeTransferOwnershipToShim} from "script/2_ProposeTransferOwnershipToShim.s.sol";
+
+/// @notice Integration tests to verify the impact of the governance upgrade on existing proposals at different
+/// lifecycle stages
+/// @dev - docs/GOVERNANCE_UPGRADE_IMPACT.md
+contract GovernanceUpgradeImpactIntegrationTest is Test, DeployInput {
+  FakeProtocolContract public fakeProtocolContract;
+  CompoundGovernorHelper public govHelper;
+  FakeProtocolRollbackTestHelper public rollbackHelper;
+  DeployScriptsIntegrationTest public deployScripts;
+  address public timelockMultiAdminShim;
+  UpgradeRegressionManager public upgradeRegressionManager;
+  CompoundGovernorHelper.Proposal public proposalBeforeUpgrade;
+  CompoundGovernorHelper.Proposal public proposalAfterUpgrade;
+
+  // Test addresses
+  address public proposer;
+
+  address public feeGuardianWhenProposalIsExecuted = makeAddr("feeGuardianWhenProposalIsExecuted");
+  uint256 public feeWhenProposalIsExecuted = 50;
+
+  address public feeGuardianWhenRollbackIsExecuted = makeAddr("feeGuardianWhenRollbackIsExecuted");
+  uint256 public feeWhenRollbackIsExecuted = 1;
+
+  function setUp() public {
+    string memory rpcUrl = vm.envString("MAINNET_RPC_URL");
+    uint256 forkBlock = 22_781_735;
+    // Create fork of mainnet
+    vm.createSelectFork(rpcUrl, forkBlock);
+    deployScripts = new DeployScriptsIntegrationTest();
+
+    (timelockMultiAdminShim, upgradeRegressionManager, govHelper, proposer) = deployScripts.onlyDeployShimAndURM();
+    // Deploy FakeProtocolContract with Compound Timelock as owner
+    fakeProtocolContract = new FakeProtocolContract(COMPOUND_TIMELOCK);
+    // Setup rollback helper and generate proposal before upgrade
+    rollbackHelper = new FakeProtocolRollbackTestHelper(fakeProtocolContract, upgradeRegressionManager);
+
+    proposalBeforeUpgrade =
+      rollbackHelper.generateProposalWithoutRollback(feeWhenProposalIsExecuted, feeGuardianWhenProposalIsExecuted);
+  }
+
+  function _proposeUpgradeAndExecuteProposalWithRoll() internal {
+    (timelockMultiAdminShim, upgradeRegressionManager, govHelper, proposer) =
+      deployScripts.onlyProposeTransferTimelockAdminToShim(timelockMultiAdminShim);
+  }
+
+  function _proposeAndQueueRollbackUpgrade(address _shimAddress)
+    private
+    returns (CompoundGovernorHelper.Proposal memory _upgradeProposal)
+  {
+    ProposeTransferOwnershipToShim _script = new ProposeTransferOwnershipToShim();
+    (address[] memory _targets, uint256[] memory _values, bytes[] memory _calldatas, string memory _description) =
+      _script.generateProposal(_shimAddress);
+
+    _upgradeProposal = CompoundGovernorHelper.Proposal(_targets, _values, _calldatas, _description);
+
+    // Propose, vote, and queue using the helper (but do NOT execute)
+    govHelper.submitPassAndQueue(proposer, _upgradeProposal);
+
+    // Roll to the block after the timelock delay
+    uint256 _timeLockDelay = govHelper.timelock().delay();
+    vm.warp(block.timestamp + _timeLockDelay + 1);
+
+    return _upgradeProposal;
+  }
+
+  function onlyProposeAndQueueTransferTimelockAdminToShim(address _timelockMultiAdminShim)
+    internal
+    returns (address, UpgradeRegressionManager, CompoundGovernorHelper, address)
+  {
+    ProposeTransferOwnershipToShim _script = new ProposeTransferOwnershipToShim();
+    _script.setLoggingSilenced(true); // Silence logging
+
+    (address[] memory targets, uint256[] memory values, bytes[] memory calldatas, string memory description) =
+      _script.generateProposal(_timelockMultiAdminShim);
+
+    CompoundGovernorHelper.Proposal memory proposal =
+      CompoundGovernorHelper.Proposal(targets, values, calldatas, description);
+
+    govHelper.submitPassAndQueue(proposer, proposal);
+    return (address(timelockMultiAdminShim), upgradeRegressionManager, govHelper, proposer);
+  }
+
+  /// @notice Test that a proposal queued before the upgrade executes via the Shim
+  function test_ProposalQueuedBeforeUpgrade_ExecutesViaShim() public {
+    // 0. Verify initial state
+    assertNotEq(fakeProtocolContract.fee(), feeWhenProposalIsExecuted);
+    assertNotEq(fakeProtocolContract.feeGuardian(), feeGuardianWhenProposalIsExecuted);
+
+    // 1. Submit, vote, and queue proposal (before upgrade)
+    govHelper.submitPassAndQueue(proposer, proposalBeforeUpgrade);
+
+    // 2. Upgrade to Shim
+    _proposeUpgradeAndExecuteProposalWithRoll();
+
+    // 3. Execute via Shim
+    govHelper.executeQueuedProposal(proposalBeforeUpgrade);
+
+    // 4. Verify execution
+    assertEq(fakeProtocolContract.fee(), feeWhenProposalIsExecuted);
+    assertEq(fakeProtocolContract.feeGuardian(), feeGuardianWhenProposalIsExecuted);
+  }
+
+  /// @notice Test that a proposal queued after the upgrade executes via the Shim
+  function test_ProposalQueuedAfterUpgrade_ExecutesViaShim() external {
+    // 0. Verify initial state
+    assertNotEq(fakeProtocolContract.fee(), feeWhenProposalIsExecuted);
+    assertNotEq(fakeProtocolContract.feeGuardian(), feeGuardianWhenProposalIsExecuted);
+
+    // 1. Upgrade to Shim
+    _proposeUpgradeAndExecuteProposalWithRoll();
+
+    // 2. Submit, vote, queue, and execute all through Governor → Shim
+    govHelper.submitPassAndQueue(proposer, proposalBeforeUpgrade);
+
+    // 3. Execute via Shim
+    govHelper.executeQueuedProposal(proposalBeforeUpgrade);
+
+    // 4. Verify execution
+    assertEq(fakeProtocolContract.fee(), feeWhenProposalIsExecuted);
+    assertEq(fakeProtocolContract.feeGuardian(), feeGuardianWhenProposalIsExecuted);
+  }
+
+  /// @notice Test that a proposal that was proposed and passed voting before the upgrade
+  /// can be queued and executed after the upgrade
+  function test_ProposalSucceededBeforeUpgrade_CanQueuePostUpgrade() external {
+    // 0. Verify initial state
+    assertNotEq(fakeProtocolContract.fee(), feeWhenProposalIsExecuted);
+    assertNotEq(fakeProtocolContract.feeGuardian(), feeGuardianWhenProposalIsExecuted);
+
+    // 1. Propose → Vote (succeeds, not queued)
+    govHelper.submitAndPassProposal(proposer, proposalBeforeUpgrade);
+
+    // 2. Upgrade to Shim
+    _proposeUpgradeAndExecuteProposalWithRoll();
+
+    // 3. Queue → Execute via Shim
+    govHelper.queueProposal(proposalBeforeUpgrade);
+    govHelper.executeQueuedProposal(proposalBeforeUpgrade);
+
+    // 4. ✅ Execution works
+    assertEq(fakeProtocolContract.fee(), feeWhenProposalIsExecuted);
+    assertEq(fakeProtocolContract.feeGuardian(), feeGuardianWhenProposalIsExecuted);
+  }
+
+  function test_ProposalVotingDuringUpgrade_ContinuesAndExecutes() external {
+    // 0. Verify initial state
+    assertNotEq(fakeProtocolContract.fee(), feeWhenProposalIsExecuted);
+    assertNotEq(fakeProtocolContract.feeGuardian(), feeGuardianWhenProposalIsExecuted);
+
+    CompoundGovernorHelper.Proposal memory _upgradeProposal = _proposeAndQueueRollbackUpgrade(timelockMultiAdminShim);
+
+    // 2. Propose and start voting on the normal proposal
+    uint256 normalProposalId = govHelper.submitProposalWithRoll(proposer, proposalBeforeUpgrade);
+    vm.roll(govHelper.governor().proposalSnapshot(normalProposalId) + 1);
+    govHelper.castVotesViaDelegates(normalProposalId, 0, 3);
+
+    // 3. Execute the upgrade proposal (timelock admin changes)
+    govHelper.executeProposal(_upgradeProposal);
+
+    // 4. Accept Admin role to the shim
+    TimelockMultiAdminShim(timelockMultiAdminShim).acceptAdmin();
+
+    // 5. Add remaining votes and queue and execute the normal proposal
+    govHelper.passProposalWithRoll(normalProposalId, 3, 6);
+    govHelper.queueProposal(proposalBeforeUpgrade);
+    govHelper.executeQueuedProposal(proposalBeforeUpgrade);
+
+    // 6. ✅ Execution works
+    assertEq(fakeProtocolContract.fee(), feeWhenProposalIsExecuted);
+    assertEq(fakeProtocolContract.feeGuardian(), feeGuardianWhenProposalIsExecuted);
+  }
+}

--- a/test/Rollback.integration.t.sol
+++ b/test/Rollback.integration.t.sol
@@ -77,7 +77,7 @@ contract ProposeWithRollback is RollbackIntegrationTest {
     _assertEqState(_rollbackId, IGovernor.ProposalState.Pending);
 
     // 5. Verify rollback is in expired state
-    vm.warp(block.timestamp + upgradeRegressionManager.rollbackQueueWindow() + 1);
+    vm.warp(block.timestamp + upgradeRegressionManager.rollbackQueueableDuration() + 1);
     _assertEqState(_rollbackId, IGovernor.ProposalState.Expired);
   }
 
@@ -217,7 +217,7 @@ contract ProposeWithRollback is RollbackIntegrationTest {
     upgradeRegressionManager.queue(targets, values, calldatas, description);
   }
 
-  function testFork_RevertIf_RollbackQueueWindowHasExpired() public {
+  function testFork_RevertIf_RollbackQueueableDurationHasExpired() public {
     // 1. Create proposal to change fee to 100
     CompoundGovernorHelper.Proposal memory proposal = rollbackHelper.generateProposalWithRollback(
       feeWhenProposalIsExecuted,
@@ -233,8 +233,8 @@ contract ProposeWithRollback is RollbackIntegrationTest {
     (address[] memory targets, uint256[] memory values, bytes[] memory calldatas, string memory description) =
       rollbackHelper.generateRollbackData(feeWhenRollbackIsExecuted, feeGuardianWhenRollbackIsExecuted);
 
-    // 4. Wait for rollback queue window to expire
-    vm.warp(block.timestamp + upgradeRegressionManager.rollbackQueueWindow() + 1);
+    // 4. Wait for rollback queueable duration to expire
+    vm.warp(block.timestamp + upgradeRegressionManager.rollbackQueueableDuration() + 1);
 
     // 5. Attempt to queue rollback
     uint256 _rollbackId = rollbackHelper.getRollbackId(feeWhenRollbackIsExecuted, feeGuardianWhenRollbackIsExecuted);

--- a/test/Rollback.integration.t.sol
+++ b/test/Rollback.integration.t.sol
@@ -66,7 +66,7 @@ contract ProposeWithRollback is RollbackIntegrationTest {
       feeGuardianWhenRollbackIsExecuted
     );
     // 2. Execute proposal using governance helper
-    govHelper.submitPassQueueAndExecuteProposal(proposer, proposal);
+    govHelper.submitPassQueueAndExecuteProposalWithRoll(proposer, proposal);
 
     // 3. Verify updated state
     assertEq(fakeProtocolContract.fee(), feeWhenProposalIsExecuted);
@@ -91,7 +91,7 @@ contract ProposeWithRollback is RollbackIntegrationTest {
     );
 
     // 2. Execute proposal using governance helper
-    govHelper.submitPassQueueAndExecuteProposal(proposer, proposal);
+    govHelper.submitPassQueueAndExecuteProposalWithRoll(proposer, proposal);
 
     // 3. Verify updated state
     assertEq(fakeProtocolContract.fee(), feeWhenProposalIsExecuted);
@@ -135,7 +135,7 @@ contract ProposeWithRollback is RollbackIntegrationTest {
 
     vm.deal(address(proposer), 1 ether);
     // 2. Execute proposal using governance helper
-    govHelper.submitPassQueueAndExecuteProposal(proposer, proposal);
+    govHelper.submitPassQueueAndExecuteProposalWithRoll(proposer, proposal);
 
     // Verify FakeProtocolContract received the ETH
     assertEq(address(fakeProtocolContract).balance, 1 ether);
@@ -171,7 +171,7 @@ contract ProposeWithRollback is RollbackIntegrationTest {
     );
 
     // 2. Execute proposal using governance helper
-    govHelper.submitPassQueueAndExecuteProposal(proposer, proposal);
+    govHelper.submitPassQueueAndExecuteProposalWithRoll(proposer, proposal);
 
     // 3. Verify updated state
     assertEq(fakeProtocolContract.fee(), feeWhenProposalIsExecuted);
@@ -227,7 +227,7 @@ contract ProposeWithRollback is RollbackIntegrationTest {
     );
 
     // 2. Execute proposal using governance helper
-    govHelper.submitPassQueueAndExecuteProposal(proposer, proposal);
+    govHelper.submitPassQueueAndExecuteProposalWithRoll(proposer, proposal);
 
     // 3. Generate rollback data
     (address[] memory targets, uint256[] memory values, bytes[] memory calldatas, string memory description) =
@@ -265,7 +265,7 @@ contract ProposeWithRollback is RollbackIntegrationTest {
     );
 
     // 2. Execute proposal using governance helper
-    govHelper.submitPassQueueAndExecuteProposal(proposer, proposal);
+    govHelper.submitPassQueueAndExecuteProposalWithRoll(proposer, proposal);
 
     // 3. Generate rollback data
     (address[] memory targets, uint256[] memory values, bytes[] memory calldatas, string memory description) =

--- a/test/fakes/FakeProtocolRollbackTestHelper.sol
+++ b/test/fakes/FakeProtocolRollbackTestHelper.sol
@@ -147,4 +147,32 @@ contract FakeProtocolRollbackTestHelper {
       description: "Proposal to set FakeProtocolContract update fee and fee guardian with ETH and emergency rollback capability"
     });
   }
+
+  function generateProposalWithoutRollback(uint256 _newFee, address _newFeeGuardian)
+    public
+    view
+    returns (CompoundGovernorHelper.Proposal memory _proposal)
+  {
+    // Generate the main proposal data (set new fee and fee guardian with ETH)
+    address[] memory _targets = new address[](2);
+    uint256[] memory _values = new uint256[](2);
+    bytes[] memory _calldatas = new bytes[](2);
+
+    // First transaction: set fee
+    _targets[0] = address(fakeProtocolContract);
+    _values[0] = 0;
+    _calldatas[0] = abi.encodeWithSelector(FakeProtocolContract.setFee.selector, _newFee);
+
+    // Second transaction: set fee guardian
+    _targets[1] = address(fakeProtocolContract);
+    _values[1] = 0;
+    _calldatas[1] = abi.encodeWithSelector(FakeProtocolContract.setFeeGuardian.selector, _newFeeGuardian);
+
+    _proposal = CompoundGovernorHelper.Proposal({
+      targets: _targets,
+      values: _values,
+      calldatas: _calldatas,
+      description: "Proposal to set FakeProtocolContract update fee and fee guardian with ETH"
+    });
+  }
 }


### PR DESCRIPTION
**Description**

- set when URM is deployed
- updated DeployInput and set min queue-able duration to 13_140
- update test
- rename `rollbackQueueWindow` -> `rollbackQueueableDuration`

closes [#11](https://github.com/ScopeLift/governance-rollback/issues/11)
closes [#36 
](https://github.com/ScopeLift/governance-rollback/issues/36)