### PR TITLE
integration/1: abstract URM core and implement Compound/OZ variants

### DIFF
--- a/src/contracts/URMCore.sol
+++ b/src/contracts/URMCore.sol
@@ -2,11 +2,10 @@
 pragma solidity ^0.8.30;
 
 // Internal Libraries
-import {ITimelockTarget} from "interfaces/ITimelockTarget.sol";
-import {IUpgradeRegressionManager} from "interfaces/IUpgradeRegressionManager.sol";
+import {IURM} from "interfaces/IURM.sol";
 import {Rollback, ProposalState} from "types/GovernanceTypes.sol";
 
-/// @title Upgrade Regression Manager
+/// @title Upgrade Rollback Manager Core
 /// @author [ScopeLift](https://scopelift.co)
 /// @notice Manages the lifecycle of rollback proposals, allowing the admin to propose, and the guardian to queue,
 /// cancel, or execute rollback transactions.
@@ -15,37 +14,37 @@ import {Rollback, ProposalState} from "types/GovernanceTypes.sol";
 ///      - Guardian queues them for execution within a specified window
 ///      - Guardian later executes or cancels the queued rollback.
 ///      - On queuing / cancelling / executing, the transactions are sent to TimelockTarget.
-contract UpgradeRegressionManager is IUpgradeRegressionManager {
+abstract contract URMCore is IURM {
   /*///////////////////////////////////////////////////////////////
                           Errors
   //////////////////////////////////////////////////////////////*/
 
   /// @notice Thrown when an unauthorized caller attempts perform an action.
-  error UpgradeRegressionManager__Unauthorized();
+  error URM__Unauthorized();
 
   /// @notice Thrown when an invalid address is provided.
-  error UpgradeRegressionManager__InvalidAddress();
+  error URM__InvalidAddress();
 
   /// @notice Thrown when an invalid rollback queueable duration is provided.
-  error UpgradeRegressionManager__InvalidRollbackQueueableDuration();
+  error URM__InvalidRollbackQueueableDuration();
 
   /// @notice Thrown when the lengths of the parameters do not match.
-  error UpgradeRegressionManager__MismatchedParameters();
+  error URM__MismatchedParameters();
 
   /// @notice Thrown when a rollback is not proposed or already queued.
-  error UpgradeRegressionManager__NotQueueable(uint256 rollbackId);
+  error URM__NotQueueable(uint256 rollbackId);
 
   /// @notice Thrown when a rollback is not queued for execution.
-  error UpgradeRegressionManager__NotQueued(uint256 rollbackId);
+  error URM__NotQueued(uint256 rollbackId);
 
   /// @notice Thrown when a rollback queue has expired.
-  error UpgradeRegressionManager__Expired(uint256 rollbackId);
+  error URM__Expired(uint256 rollbackId);
 
   /// @notice Thrown when a rollback's execution time has not yet arrived.
-  error UpgradeRegressionManager__ExecutionTooEarly(uint256 rollbackId);
+  error URM__ExecutionTooEarly(uint256 rollbackId);
 
   /// @notice Thrown when a rollback already exists.
-  error UpgradeRegressionManager__AlreadyExists(uint256 rollbackId);
+  error URM__AlreadyExists(uint256 rollbackId);
 
   /*///////////////////////////////////////////////////////////////
                           Events
@@ -100,7 +99,7 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
   //////////////////////////////////////////////////////////////*/
 
   /// @notice Target for timelocked execution of rollback transactions.
-  ITimelockTarget public immutable TARGET;
+  address public immutable TARGET;
 
   /// @notice The lower bound enforced for the rollbackQueueableDuration setting.
   uint256 public immutable MIN_ROLLBACK_QUEUEABLE_DURATION;
@@ -116,13 +115,13 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
   uint256 public rollbackQueueableDuration;
 
   /// @notice Rollback id to rollback data.
-  mapping(uint256 rollbackId => Rollback) private _rollbacks;
+  mapping(uint256 rollbackId => Rollback) internal _rollbacks;
 
   /*///////////////////////////////////////////////////////////////
                           Constructor
   //////////////////////////////////////////////////////////////*/
 
-  /// @notice Initializes the UpgradeRegressionManager.
+  /// @notice Initializes the URM.
   /// @param _target The target for timelocked execution of rollback transactions.
   /// @param _admin The address that manages this contract.
   /// @param _guardian The address that can execute rollback transactions.
@@ -131,18 +130,18 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
   /// @param _minRollbackQueueableDuration The lower bound enforced for the rollbackQueueableDuration setting (in
   /// seconds).
   constructor(
-    ITimelockTarget _target,
+    address _target,
     address _admin,
     address _guardian,
     uint256 _rollbackQueueableDuration,
     uint256 _minRollbackQueueableDuration
   ) {
     if (_minRollbackQueueableDuration == 0) {
-      revert UpgradeRegressionManager__InvalidRollbackQueueableDuration();
+      revert URM__InvalidRollbackQueueableDuration();
     }
 
     if (address(_target) == address(0)) {
-      revert UpgradeRegressionManager__InvalidAddress();
+      revert URM__InvalidAddress();
     }
 
     TARGET = _target;
@@ -188,7 +187,7 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
 
     // Revert if the rollback already exists.
     if (_getState(_rollback) != ProposalState.Unknown) {
-      revert UpgradeRegressionManager__AlreadyExists(_rollbackId);
+      revert URM__AlreadyExists(_rollbackId);
     }
 
     // Set the time before which the rollback can be queued for execution.
@@ -226,19 +225,17 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
     if (_state != ProposalState.Pending) {
       // Custom revert if the rollback queue has expired.
       if (_state == ProposalState.Expired) {
-        revert UpgradeRegressionManager__Expired(_rollbackId);
+        revert URM__Expired(_rollbackId);
       }
-      revert UpgradeRegressionManager__NotQueueable(_rollbackId);
+      revert URM__NotQueueable(_rollbackId);
     }
 
     // Set the time after which the queued rollback can be executed.
-    uint256 _eta = block.timestamp + TARGET.delay();
+    uint256 _eta = block.timestamp + _delay();
     _rollback.executableAt = _eta;
 
-    // Queue the rollback transactions.
-    for (uint256 _i = 0; _i < _targets.length; _i++) {
-      TARGET.queueTransaction(_targets[_i], _values[_i], "", _calldatas[_i], _eta);
-    }
+    // Queue the rollback to the timelock target.
+    _queue(_targets, _values, _calldatas, _description);
 
     emit RollbackQueued(_rollbackId, _eta);
   }
@@ -268,13 +265,11 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
 
     // Revert if the rollback has been queued or is ready to be executed.
     if (_state != ProposalState.Queued && _state != ProposalState.Active) {
-      revert UpgradeRegressionManager__NotQueued(_rollbackId);
+      revert URM__NotQueued(_rollbackId);
     }
 
-    // Cancel the rollback transactions.
-    for (uint256 _i = 0; _i < _targets.length; _i++) {
-      TARGET.cancelTransaction(_targets[_i], _values[_i], "", _calldatas[_i], _rollback.executableAt);
-    }
+    // Cancel the rollback transactions on the timelock target.
+    _cancel(_targets, _values, _calldatas, _description);
 
     _rollback.canceled = true;
 
@@ -308,15 +303,13 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
     if (_state != ProposalState.Active) {
       // Custom revert if the rollback is queued for execution but the execution time has not arrived.
       if (_state == ProposalState.Queued) {
-        revert UpgradeRegressionManager__ExecutionTooEarly(_rollbackId);
+        revert URM__ExecutionTooEarly(_rollbackId);
       }
-      revert UpgradeRegressionManager__NotQueued(_rollbackId);
+      revert URM__NotQueued(_rollbackId);
     }
 
-    // Execute the rollback.
-    for (uint256 _i = 0; _i < _targets.length; _i++) {
-      TARGET.executeTransaction(_targets[_i], _values[_i], "", _calldatas[_i], _rollback.executableAt);
-    }
+    // Execute the rollback on the timelock target.
+    _execute(_targets, _values, _calldatas, _description);
 
     _rollback.executed = true;
 
@@ -364,9 +357,7 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
     uint256[] memory _values,
     bytes[] memory _calldatas,
     string memory _description
-  ) public pure returns (uint256) {
-    return uint256(keccak256(abi.encode(_targets, _values, _calldatas, _description)));
-  }
+  ) public view virtual returns (uint256);
 
   /// @notice Returns the current state of a proposed rollback by its ID.
   /// @param _rollbackId The ID of the rollback to check.
@@ -381,14 +372,14 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
   /// @notice Reverts if the caller is not the admin.
   function _revertIfNotAdmin() internal view {
     if (msg.sender != admin) {
-      revert UpgradeRegressionManager__Unauthorized();
+      revert URM__Unauthorized();
     }
   }
 
   /// @notice Reverts if the caller is not the guardian.
   function _revertIfNotGuardian() internal view {
     if (msg.sender != guardian) {
-      revert UpgradeRegressionManager__Unauthorized();
+      revert URM__Unauthorized();
     }
   }
 
@@ -401,7 +392,7 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
     pure
   {
     if (_targets.length != _values.length || _targets.length != _calldatas.length) {
-      revert UpgradeRegressionManager__MismatchedParameters();
+      revert URM__MismatchedParameters();
     }
   }
 
@@ -409,7 +400,7 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
   /// @param _newGuardian The new guardian.
   function _setGuardian(address _newGuardian) internal {
     if (_newGuardian == address(0)) {
-      revert UpgradeRegressionManager__InvalidAddress();
+      revert URM__InvalidAddress();
     }
 
     emit GuardianSet(guardian, _newGuardian);
@@ -420,7 +411,7 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
   /// @param _newRollbackQueueableDuration The new rollback queueable duration (in seconds).
   function _setRollbackQueueableDuration(uint256 _newRollbackQueueableDuration) internal {
     if (_newRollbackQueueableDuration < MIN_ROLLBACK_QUEUEABLE_DURATION) {
-      revert UpgradeRegressionManager__InvalidRollbackQueueableDuration();
+      revert URM__InvalidRollbackQueueableDuration();
     }
 
     emit RollbackQueueableDurationSet(rollbackQueueableDuration, _newRollbackQueueableDuration);
@@ -431,7 +422,7 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
   /// @param _newAdmin The new admin.
   function _setAdmin(address _newAdmin) internal {
     if (_newAdmin == address(0)) {
-      revert UpgradeRegressionManager__InvalidAddress();
+      revert URM__InvalidAddress();
     }
 
     emit AdminSet(admin, _newAdmin);
@@ -484,4 +475,48 @@ contract UpgradeRegressionManager is IUpgradeRegressionManager {
     // Rollback is proposed but not queued for execution.
     return ProposalState.Pending;
   }
+
+  /*///////////////////////////////////////////////////////////////
+                      Target Interaction Hooks
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Returns the delay of the timelock target.
+  /// @return The delay of the timelock target.
+  function _delay() internal view virtual returns (uint256);
+
+  /// @notice Queues a rollback to the timelock target.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  /// @param _description The description of the rollback.
+  function _queue(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) internal virtual;
+
+  /// @notice Cancels a rollback on the timelock target.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  /// @param _description The description of the rollback.
+  function _cancel(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) internal virtual;
+
+  /// @notice Executes a rollback on the timelock target.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  /// @param _description The description of the rollback.
+  function _execute(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) internal virtual;
 }

--- a/src/contracts/URMCore.sol
+++ b/src/contracts/URMCore.sol
@@ -13,7 +13,7 @@ import {Rollback, ProposalState} from "types/GovernanceTypes.sol";
 ///      - Admin proposes rollback transactions.
 ///      - Guardian queues them for execution within a specified window
 ///      - Guardian later executes or cancels the queued rollback.
-///      - On queuing / cancelling / executing, the transactions are sent to TimelockTarget.
+///      - On queuing / cancelling / executing, the transactions are sent to TARGET_TIMELOCK.
 abstract contract URMCore is IURM {
   /*///////////////////////////////////////////////////////////////
                           Errors
@@ -99,7 +99,7 @@ abstract contract URMCore is IURM {
   //////////////////////////////////////////////////////////////*/
 
   /// @notice Target for timelocked execution of rollback transactions.
-  address public immutable TARGET;
+  address public immutable TARGET_TIMELOCK;
 
   /// @notice The lower bound enforced for the rollbackQueueableDuration setting.
   uint256 public immutable MIN_ROLLBACK_QUEUEABLE_DURATION;
@@ -122,7 +122,7 @@ abstract contract URMCore is IURM {
   //////////////////////////////////////////////////////////////*/
 
   /// @notice Initializes the URM.
-  /// @param _target The target for timelocked execution of rollback transactions.
+  /// @param _targetTimelock The target for timelocked execution of rollback transactions.
   /// @param _admin The address that manages this contract.
   /// @param _guardian The address that can execute rollback transactions.
   /// @param _rollbackQueueableDuration The duration within which a proposed rollback remains eligible to be queued for
@@ -130,7 +130,7 @@ abstract contract URMCore is IURM {
   /// @param _minRollbackQueueableDuration The lower bound enforced for the rollbackQueueableDuration setting (in
   /// seconds).
   constructor(
-    address _target,
+    address _targetTimelock,
     address _admin,
     address _guardian,
     uint256 _rollbackQueueableDuration,
@@ -140,11 +140,11 @@ abstract contract URMCore is IURM {
       revert URM__InvalidRollbackQueueableDuration();
     }
 
-    if (address(_target) == address(0)) {
+    if (address(_targetTimelock) == address(0)) {
       revert URM__InvalidAddress();
     }
 
-    TARGET = _target;
+    TARGET_TIMELOCK = _targetTimelock;
     MIN_ROLLBACK_QUEUEABLE_DURATION = _minRollbackQueueableDuration;
 
     _setAdmin(_admin);
@@ -344,7 +344,7 @@ abstract contract URMCore is IURM {
                           Public Functions
   //////////////////////////////////////////////////////////////*/
 
-  /// @notice Calculates the rollback ID for a given set of parameters.
+  /// @notice Calculates the rollback id for a given set of parameters.
   /// @param _targets The targets of the transactions.
   /// @param _values The values of the transactions.
   /// @param _calldatas The calldatas of the transactions.
@@ -480,8 +480,8 @@ abstract contract URMCore is IURM {
                       Target Interaction Hooks
   //////////////////////////////////////////////////////////////*/
 
-  /// @notice Returns the delay of the timelock target.
-  /// @return The delay of the timelock target.
+  /// @notice Returns the minimum delay required by the timelock target before a queued rollback can be executed.
+  /// @return The delay in seconds that must elapse between queueing and executing a rollback.
   function _delay() internal view virtual returns (uint256);
 
   /// @notice Queues a rollback to the timelock target.

--- a/src/contracts/urm/URMCompoundTimelock.sol
+++ b/src/contracts/urm/URMCompoundTimelock.sol
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+// Internal Libraries
+import {URMCore} from "contracts/URMCore.sol";
+import {ICompoundTimelockTarget} from "interfaces/ICompoundTimelockTarget.sol";
+
+/// @title URMCompoundTimelock
+/// @author [ScopeLift](https://scopelift.co)
+/// @notice Integrates URMCore with a Compound-style Timelock contract as the execution target.
+/// @dev This contract implements the rollback proposal lifecycle using Compound's Timelock interface.
+///      It interacts with the target using individual `queueTransaction`, `cancelTransaction`, and `executeTransaction`
+/// calls for each action.
+///      Usecase:
+///        - Use this contract when your system uses Compound-style Timelocks, often found in simpler or more minimal
+/// governance systems (e.g., Compound, Fuse, etc.).
+///      Key Differences from URMTimelockController:
+///       - Queues, cancels, and executes each transaction individually (per `queueTransaction`).
+///       - Computes rollback IDs using `keccak256(abi.encode(...))` of the batch parameters.
+///       - Uses the `delay()` function on the target contract to determine delay.
+///       - No batch operation support or salt-based identifiers — relies purely on encoded parameters and ETA.
+///      Requirements:
+///        - The `TARGET` must conform to the `ICompoundTimelockTarget` interface, compatible with Compound’s Timelock.
+/// @dev Source:
+/// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/ba35d580f47ba90494eb9f3d26f58f7949b10c67/contracts/vendor/compound/ICompoundTimelock.sol
+contract URMCompoundTimelock is URMCore {
+  /*///////////////////////////////////////////////////////////////
+                          Constructor
+  //////////////////////////////////////////////////////////////*/
+
+  constructor(
+    address _target,
+    address _admin,
+    address _guardian,
+    uint256 _rollbackQueueableDuration,
+    uint256 _minRollbackQueueableDuration
+  ) URMCore(_target, _admin, _guardian, _rollbackQueueableDuration, _minRollbackQueueableDuration) {}
+
+  /*///////////////////////////////////////////////////////////////
+                          Overrides
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Returns the rollback ID for a given set of parameters.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  /// @param _description The description of the rollback.
+  /// @return The rollback ID.
+  /// @dev This rollback id can be produced from the rollback data which is part of the {RollbackCreated} event.
+  ///      It can even be computed in advance, before the rollback is proposed.
+  /// @dev Source:
+  /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/ba35d580f47ba90494eb9f3d26f58f7949b10c67/contracts/governance/extensions/GovernorTimelockCompound.sol#L75
+  function getRollbackId(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) public pure override returns (uint256) {
+    return uint256(keccak256(abi.encode(_targets, _values, _calldatas, _description)));
+  }
+
+  /// @notice Returns the delay of the timelock target.
+  /// @return The delay of the timelock target.
+  /// @dev Source:
+  /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/ba35d580f47ba90494eb9f3d26f58f7949b10c67/contracts/vendor/compound/ICompoundTimelock.sol#L53
+  function _delay() internal view override returns (uint256) {
+    return ICompoundTimelockTarget(TARGET).delay();
+  }
+
+  /// @notice Queues a rollback to the timelock target.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  /// @param _description The description of the rollback.
+  /// @dev Source:
+  /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/ba35d580f47ba90494eb9f3d26f58f7949b10c67/contracts/vendor/compound/ICompoundTimelock.sol#L63-L69
+  function _queue(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) internal override {
+    uint256 _executableAt = _getRollbackExecutableAt(_targets, _values, _calldatas, _description);
+
+    for (uint256 _i = 0; _i < _targets.length; _i++) {
+      ICompoundTimelockTarget(TARGET).queueTransaction(_targets[_i], _values[_i], "", _calldatas[_i], _executableAt);
+    }
+  }
+
+  /// @notice Cancels a rollback on the timelock target.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  /// @param _description The description of the rollback.
+  /// @dev Source:
+  /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/ba35d580f47ba90494eb9f3d26f58f7949b10c67/contracts/vendor/compound/ICompoundTimelock.sol#L71-L77
+  function _cancel(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) internal override {
+    uint256 _executableAt = _getRollbackExecutableAt(_targets, _values, _calldatas, _description);
+
+    for (uint256 _i = 0; _i < _targets.length; _i++) {
+      ICompoundTimelockTarget(TARGET).cancelTransaction(_targets[_i], _values[_i], "", _calldatas[_i], _executableAt);
+    }
+  }
+
+  /// @notice Executes a rollback on the timelock target.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  /// @param _description The description of the rollback.
+  /// @dev Source:
+  /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/ba35d580f47ba90494eb9f3d26f58f7949b10c67/contracts/vendor/compound/ICompoundTimelock.sol#L79-L85
+  function _execute(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) internal override {
+    uint256 _executableAt = _getRollbackExecutableAt(_targets, _values, _calldatas, _description);
+
+    for (uint256 _i = 0; _i < _targets.length; _i++) {
+      ICompoundTimelockTarget(TARGET).executeTransaction(_targets[_i], _values[_i], "", _calldatas[_i], _executableAt);
+    }
+  }
+
+  /*///////////////////////////////////////////////////////////////
+                          Internal Functions
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Utility to return the executableAt timestamp for a rollback.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  /// @param _description The description of the rollback.
+  /// @return The executableAt timestamp for the rollback.
+  function _getRollbackExecutableAt(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) internal view returns (uint256) {
+    uint256 _rollbackId = getRollbackId(_targets, _values, _calldatas, _description);
+    return _rollbacks[_rollbackId].executableAt;
+  }
+}

--- a/src/contracts/urm/URMTimelockController.sol
+++ b/src/contracts/urm/URMTimelockController.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {URMCore} from "contracts/URMCore.sol";
+import {ITimelockControllerTarget} from "interfaces/ITimelockControllerTarget.sol";
+
+/// @title URMTimelockController
+/// @author [ScopeLift](https://scopelift.co)
+/// @notice Integrates URMCore with an OpenZeppelin-style TimelockController as the execution target.
+/// @dev This contract implements the rollback proposal lifecycle using OZ's TimelockController interface.
+///      It derives the rollback ID via OZ's `hashOperationBatch` and interacts with the target using `scheduleBatch`,
+/// `executeBatch`, and `cancel`.
+///      Usecase:
+///        - Use this contract when your system uses OpenZeppelin's TimelockController, typically found in
+/// Governor-based governance setups.
+///      Key Differences from URMCompoundTimelock:
+///        - Calls OZ's `scheduleBatch`, `cancel`, and `executeBatch` on the timelock target.
+///        - Computes rollback IDs using `hashOperationBatch` with a salt derived from the contract address and
+/// description.
+///        - Delay is fetched via `getMinDelay()` on the timelock.
+///        - No per-transaction queueing — batch is scheduled/executed as a whole.
+///      Requirements:
+///        - The `TARGET` must conform to the `ITimelockControllerTarget` interface, which mirrors the OZ
+/// TimelockController API.
+/// @dev Source:
+/// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/ba35d580f47ba90494eb9f3d26f58f7949b10c67/contracts/governance/TimelockController.sol
+contract URMTimelockController is URMCore {
+  /*///////////////////////////////////////////////////////////////
+                          Constructor
+  //////////////////////////////////////////////////////////////*/
+
+  constructor(
+    address _target,
+    address _admin,
+    address _guardian,
+    uint256 _rollbackQueueableDuration,
+    uint256 _minRollbackQueueableDuration
+  ) URMCore(_target, _admin, _guardian, _rollbackQueueableDuration, _minRollbackQueueableDuration) {}
+
+  /*///////////////////////////////////////////////////////////////
+                          Overrides
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Returns the rollback ID for a given set of parameters.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  /// @param _description The description of the rollback.
+  /// @return The rollback ID.
+  /// @dev This rollback id can be produced from the rollback data which is part of the {RollbackCreated} event.
+  ///      It can even be computed in advance, before the rollback is proposed.
+  function getRollbackId(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) public view override returns (uint256) {
+    return uint256(_getRollbackHash(_targets, _values, _calldatas, _description));
+  }
+
+  /// @notice Returns the delay of the timelock target.
+  /// @return The delay of the timelock target.
+  /// @dev Source:
+  /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/ba35d580f47ba90494eb9f3d26f58f7949b10c67/contracts/governance/TimelockController.sol#L224-L226
+  function _delay() internal view override returns (uint256) {
+    return ITimelockControllerTarget(TARGET).getMinDelay();
+  }
+
+  /// @notice Schedules a rollback to the timelock target.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  /// @param _description The description of the rollback.
+  /// @dev Source:
+  /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/ba35d580f47ba90494eb9f3d26f58f7949b10c67/contracts/governance/extensions/GovernorTimelockControl.sol#L87-L88
+  function _queue(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) internal override {
+    ITimelockControllerTarget(TARGET).scheduleBatch(
+      _targets, _values, _calldatas, 0, _timelockSalt(_description), _delay()
+    );
+  }
+
+  /// @notice Cancels a rollback on the timelock target.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  /// @param _description The description of the rollback.
+  /// @dev Source:
+  /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/ba35d580f47ba90494eb9f3d26f58f7949b10c67/contracts/governance/extensions/GovernorTimelockControl.sol#L128
+  function _cancel(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) internal override {
+    ITimelockControllerTarget(TARGET).cancel(_getRollbackHash(_targets, _values, _calldatas, _description));
+  }
+
+  /// @notice Executes a rollback on the timelock target.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  /// @param _description The description of the rollback.
+  /// @dev Source:
+  /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/ba35d580f47ba90494eb9f3d26f58f7949b10c67/contracts/governance/extensions/GovernorTimelockControl.sol#L105
+  function _execute(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) internal override {
+    ITimelockControllerTarget(TARGET).executeBatch{value: msg.value}(
+      _targets, _values, _calldatas, 0, _timelockSalt(_description)
+    );
+  }
+
+  /*///////////////////////////////////////////////////////////////
+                          Internal Functions
+  //////////////////////////////////////////////////////////////*/
+
+  /// @notice Returns the salt for the operation.
+  /// @param _description The description of the rollback.
+  /// @return The salt for the operation.
+  /// @dev Source:
+  /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/ba35d580f47ba90494eb9f3d26f58f7949b10c67/contracts/governance/extensions/GovernorTimelockControl.sol#L164C1-L166C6
+  function _timelockSalt(string memory _description) internal view returns (bytes32) {
+    return bytes20(address(this)) ^ keccak256(bytes(_description));
+  }
+
+  /// @notice Returns the hash of the rollback operation.
+  /// @param _targets The targets of the transactions.
+  /// @param _values The values of the transactions.
+  /// @param _calldatas The calldatas of the transactions.
+  /// @param _description The description of the rollback.
+  /// @return The hash of the rollback operation.
+  /// @dev Source:
+  /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/ba35d580f47ba90494eb9f3d26f58f7949b10c67/contracts/governance/extensions/GovernorTimelockControl.sol#L87
+  function _getRollbackHash(
+    address[] memory _targets,
+    uint256[] memory _values,
+    bytes[] memory _calldatas,
+    string memory _description
+  ) internal view returns (bytes32) {
+    return ITimelockControllerTarget(TARGET).hashOperationBatch(
+      _targets, _values, _calldatas, 0, _timelockSalt(_description)
+    );
+  }
+}

--- a/src/contracts/urm/URMTimelockController.sol
+++ b/src/contracts/urm/URMTimelockController.sol
@@ -20,7 +20,7 @@ import {ITimelockControllerTarget} from "interfaces/ITimelockControllerTarget.so
 ///        - Delay is fetched via `getMinDelay()` on the timelock.
 ///        - No per-transaction queueing — batch is scheduled/executed as a whole.
 ///      Requirements:
-///        - The `TARGET` must conform to the `ITimelockControllerTarget` interface, which mirrors the OZ
+///        - The `TARGET_TIMELOCK` must conform to the `ITimelockControllerTarget` interface, which mirrors the OZ
 /// TimelockController API.
 /// @dev Source:
 /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/ba35d580f47ba90494eb9f3d26f58f7949b10c67/contracts/governance/TimelockController.sol
@@ -41,7 +41,7 @@ contract URMTimelockController is URMCore {
                           Overrides
   //////////////////////////////////////////////////////////////*/
 
-  /// @notice Returns the rollback ID for a given set of parameters.
+  /// @notice Returns the rollback id for a given set of parameters.
   /// @param _targets The targets of the transactions.
   /// @param _values The values of the transactions.
   /// @param _calldatas The calldatas of the transactions.
@@ -58,12 +58,12 @@ contract URMTimelockController is URMCore {
     return uint256(_getRollbackHash(_targets, _values, _calldatas, _description));
   }
 
-  /// @notice Returns the delay of the timelock target.
-  /// @return The delay of the timelock target.
+  /// @notice Returns the minimum delay required by the timelock target before a queued rollback can be executed.
+  /// @return The delay in seconds that must elapse between queueing and executing a rollback.
   /// @dev Source:
   /// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/ba35d580f47ba90494eb9f3d26f58f7949b10c67/contracts/governance/TimelockController.sol#L224-L226
   function _delay() internal view override returns (uint256) {
-    return ITimelockControllerTarget(TARGET).getMinDelay();
+    return ITimelockControllerTarget(TARGET_TIMELOCK).getMinDelay();
   }
 
   /// @notice Schedules a rollback to the timelock target.
@@ -79,7 +79,7 @@ contract URMTimelockController is URMCore {
     bytes[] memory _calldatas,
     string memory _description
   ) internal override {
-    ITimelockControllerTarget(TARGET).scheduleBatch(
+    ITimelockControllerTarget(TARGET_TIMELOCK).scheduleBatch(
       _targets, _values, _calldatas, 0, _timelockSalt(_description), _delay()
     );
   }
@@ -97,7 +97,7 @@ contract URMTimelockController is URMCore {
     bytes[] memory _calldatas,
     string memory _description
   ) internal override {
-    ITimelockControllerTarget(TARGET).cancel(_getRollbackHash(_targets, _values, _calldatas, _description));
+    ITimelockControllerTarget(TARGET_TIMELOCK).cancel(_getRollbackHash(_targets, _values, _calldatas, _description));
   }
 
   /// @notice Executes a rollback on the timelock target.
@@ -113,7 +113,7 @@ contract URMTimelockController is URMCore {
     bytes[] memory _calldatas,
     string memory _description
   ) internal override {
-    ITimelockControllerTarget(TARGET).executeBatch{value: msg.value}(
+    ITimelockControllerTarget(TARGET_TIMELOCK).executeBatch{value: msg.value}(
       _targets, _values, _calldatas, 0, _timelockSalt(_description)
     );
   }
@@ -145,7 +145,7 @@ contract URMTimelockController is URMCore {
     bytes[] memory _calldatas,
     string memory _description
   ) internal view returns (bytes32) {
-    return ITimelockControllerTarget(TARGET).hashOperationBatch(
+    return ITimelockControllerTarget(TARGET_TIMELOCK).hashOperationBatch(
       _targets, _values, _calldatas, 0, _timelockSalt(_description)
     );
   }

--- a/src/interfaces/ICompoundTimelockTarget.sol
+++ b/src/interfaces/ICompoundTimelockTarget.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.30;
 
 /// @title ICompoundTimelockTarget
 /// @author [ScopeLift](https://scopelift.co)
-/// @notice Minimal interface for interacting with a timelock-compatible target used by URM.
+/// @notice Minimal interface for interacting with a Compound timelock-compatible target used by URM.
 /// @dev This interface represents a simplified subset of the
 ///      [ICompoundTimelock](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/6079eb3f01d5a37ae23e7e72d6909852566bc2e3/contracts/vendor/compound/ICompoundTimelock.sol)
 ///      contract, tailored for use by URM.

--- a/src/interfaces/ICompoundTimelockTarget.sol
+++ b/src/interfaces/ICompoundTimelockTarget.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.30;
 
-/// @title ITimelockTarget
+/// @title ICompoundTimelockTarget
 /// @author [ScopeLift](https://scopelift.co)
-/// @notice Minimal interface for interacting with a timelock-compatible target used by UpgradeRegressionManager.
+/// @notice Minimal interface for interacting with a timelock-compatible target used by URM.
 /// @dev This interface represents a simplified subset of the
 ///      [ICompoundTimelock](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/6079eb3f01d5a37ae23e7e72d6909852566bc2e3/contracts/vendor/compound/ICompoundTimelock.sol)
-///      contract, tailored for use by UpgradeRegressionManager.
-interface ITimelockTarget {
+///      contract, tailored for use by URM.
+interface ICompoundTimelockTarget {
   /// @notice Queues a transaction on the timelock.
   /// @param target The address of the contract to call.
   /// @param value The value to send with the transaction.

--- a/src/interfaces/ITimelockControllerTarget.sol
+++ b/src/interfaces/ITimelockControllerTarget.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @title ITimelockControllerTarget
+/// @author [ScopeLift](https://scopelift.co)
+/// @notice Minimal interface for interacting with a timelock-compatible target used by URM.
+/// @dev This interface represents a simplified subset of the
+///      [TimelockController](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/ba35d580f47ba90494eb9f3d26f58f7949b10c67/contracts/governance/TimelockController.sol)
+///      contract, tailored for use by URM.
+interface ITimelockControllerTarget {
+  /// @notice Schedules a batch of transactions for execution.
+  /// @param targets The targets of the transactions.
+  /// @param values The values of the transactions.
+  /// @param calldatas The calldatas of the transactions.
+  /// @param predecessor The predecessor of the transactions.
+  /// @param salt The salt of the transactions.
+  /// @param delay The delay of the transactions.
+  function scheduleBatch(
+    address[] memory targets,
+    uint256[] memory values,
+    bytes[] memory calldatas,
+    bytes32 predecessor,
+    bytes32 salt,
+    uint256 delay
+  ) external;
+
+  /// @notice Cancels a rollback.
+  /// @param rollbackId The rollback ID.
+  function cancel(bytes32 rollbackId) external;
+
+  /// @notice Executes a batch of transactions.
+  /// @param targets The targets of the transactions.
+  /// @param values The values of the transactions.
+  /// @param calldatas The calldatas of the transactions.
+  /// @param predecessor The predecessor of the transactions.
+  /// @param salt The salt of the transactions.
+  function executeBatch(
+    address[] memory targets,
+    uint256[] memory values,
+    bytes[] memory calldatas,
+    bytes32 predecessor,
+    bytes32 salt
+  ) external payable;
+
+  /// @notice Returns the minimum delay of the timelock.
+  /// @return The minimum delay of the timelock.
+  function getMinDelay() external view returns (uint256);
+
+  /// @notice Returns the hash of the batch operation.
+  /// @param targets The targets of the transactions.
+  /// @param values The values of the transactions.
+  /// @param payloads The payloads of the transactions.
+  /// @param predecessor The predecessor of the transactions.
+  /// @param salt The salt of the transactions.
+  /// @return The hash of the batch operation.
+  function hashOperationBatch(
+    address[] calldata targets,
+    uint256[] calldata values,
+    bytes[] calldata payloads,
+    bytes32 predecessor,
+    bytes32 salt
+  ) external view returns (bytes32);
+}

--- a/src/interfaces/ITimelockControllerTarget.sol
+++ b/src/interfaces/ITimelockControllerTarget.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.30;
 
 /// @title ITimelockControllerTarget
 /// @author [ScopeLift](https://scopelift.co)
-/// @notice Minimal interface for interacting with a timelock-compatible target used by URM.
+/// @notice Minimal interface for interacting with an OZ timelock-compatible target used by URM.
 /// @dev This interface represents a simplified subset of the
 ///      [TimelockController](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/ba35d580f47ba90494eb9f3d26f58f7949b10c67/contracts/governance/TimelockController.sol)
 ///      contract, tailored for use by URM.

--- a/src/interfaces/IURM.sol
+++ b/src/interfaces/IURM.sol
@@ -2,15 +2,14 @@
 pragma solidity ^0.8.30;
 
 // Internal Libraries
-import {ITimelockTarget} from "interfaces/ITimelockTarget.sol";
 import {Rollback, ProposalState} from "types/GovernanceTypes.sol";
 
-interface IUpgradeRegressionManager {
+interface IURM {
   /*///////////////////////////////////////////////////////////////
                      Public Storage 
   //////////////////////////////////////////////////////////////*/
 
-  function TARGET() external view returns (ITimelockTarget);
+  function TARGET() external view returns (address);
 
   function admin() external view returns (address);
 

--- a/src/interfaces/IURM.sol
+++ b/src/interfaces/IURM.sol
@@ -9,7 +9,7 @@ interface IURM {
                      Public Storage 
   //////////////////////////////////////////////////////////////*/
 
-  function TARGET() external view returns (address);
+  function TARGET_TIMELOCK() external view returns (address);
 
   function admin() external view returns (address);
 

--- a/test/DeployScripts.integration.t.sol.tmp
+++ b/test/DeployScripts.integration.t.sol.tmp
@@ -129,7 +129,7 @@ contract DeployScriptsIntegrationTest is Test, DeployInput {
     assertEq(address(timelockMultiAdminShim.TIMELOCK()), COMPOUND_TIMELOCK);
     assertEq(timelockMultiAdminShim.admin(), COMPOUND_GOVERNOR);
     assertTrue(timelockMultiAdminShim.isExecutor(address(upgradeRegressionManager)));
-    assertEq(address(upgradeRegressionManager.TARGET()), address(timelockMultiAdminShim));
+    assertEq(address(upgradeRegressionManager.TARGET_TIMELOCK()), address(timelockMultiAdminShim));
     assertEq(upgradeRegressionManager.admin(), COMPOUND_TIMELOCK);
     assertEq(upgradeRegressionManager.guardian(), GUARDIAN);
     assertEq(upgradeRegressionManager.rollbackQueueableDuration(), ROLLBACK_QUEUEABLE_DURATION);

--- a/test/fakes/FakeProtocolRollbackTestHelper.sol.tmp
+++ b/test/fakes/FakeProtocolRollbackTestHelper.sol.tmp
@@ -46,7 +46,7 @@ contract FakeProtocolRollbackTestHelper {
     _description = "Emergency rollback for FakeProtocolContract";
   }
 
-  /// @notice Generates the rollback ID for a given set of parameters
+  /// @notice Generates the rollback id for a given set of parameters
   /// @param _rollbackFee The rollback fee to set
   /// @param _rollbackFeeGuardian The rollback fee guardian to set
   /// @return The rollback ID


### PR DESCRIPTION
**Description**

- rename UpgradeRegressionManager to URM
- replace UpgradeRegressionManager.sol to abstract URMCore.sol
- add hooks function which need to be overriden by URM implementation
- implement hooks for compound version of URM
- implement hooks for oz version of URM
- update natspec comments
- fix scripts

